### PR TITLE
 no-referesh email verification flow details will be included in PR

### DIFF
--- a/my-app/app/api/auth/profile-status/route.ts
+++ b/my-app/app/api/auth/profile-status/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     // Convert to boolean (string 'true' becomes true, anything else is false)
     const justLoggedIn = justLoggedInParam === 'true';
     
-    const supabase = createClient();
+    const supabase = await createClient();
     
     // Check if user is authenticated (secure)
     const { data: { user }, error: userError } = await supabase.auth.getUser();

--- a/my-app/app/auth/callback/page.tsx
+++ b/my-app/app/auth/callback/page.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * Handles both OAuth and magic-link redirects.
+ * – Exchanges ?code=… for a session in the browser.
+ * – Broadcasts "emailVerified" so the waiting page knows instantly.
+ * – Redirects to "/" (AuthProvider will take the user to /profile/setup
+ *   if their profile is incomplete).
+ */
+export default function AuthCallback() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    const finishAuth = async () => {
+      // Supabase v2: no arg needed; grabs code from window.location
+      const { error } = await supabase.auth.exchangeCodeForSession();
+      if (error) {
+        // land on login with a friendly error message
+        router.replace(`/auth/login?error=${encodeURIComponent(error.message)}`);
+        return;
+      }
+
+      // Tell any open /auth/waiting tab that we've verified
+      localStorage.setItem("emailVerified", "true");
+
+      // Go to the app root; AuthProvider will route further
+      router.replace("/");
+    };
+
+    finishAuth();
+  }, []);
+
+  return (
+    <main className="flex h-screen items-center justify-center">
+      <p className="text-muted-foreground">Finishing sign-in…</p>
+    </main>
+  );
+}

--- a/my-app/app/layout.tsx
+++ b/my-app/app/layout.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from "@/lib/auth";
 import ClientLayout from "@/components/client-layout";
 import Navbar from "@/components/navbar";
 import { Toaster } from "sonner";
+import RootCodeRedirect from "./root-code-redirect"; // already imported
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -31,7 +32,12 @@ export default function RootLayout({
         >
           <AuthProvider>
             <Navbar />
-            <ClientLayout>{children}</ClientLayout>
+            <ClientLayout>
+              {/* *** TEMP NEW *** — wrap site content so "/?code=…" forwards
+                   to "/auth/callback?code=…" until Supabase redirect
+                   URLs are updated */}
+              <RootCodeRedirect>{children}</RootCodeRedirect>
+            </ClientLayout>
             <Toaster position="top-right" richColors closeButton />
           </AuthProvider>
         </ThemeProvider>

--- a/my-app/app/root-code-redirect.tsx
+++ b/my-app/app/root-code-redirect.tsx
@@ -1,0 +1,24 @@
+/**
+ * TEMPORARY fix: If Supabase sends the user to "/?code=…", forward them
+ * to "/auth/callback?code=…" so the new session logic runs.
+ *
+ * We can remove this once the Supabase redirect URL list includes
+ *   …/auth/callback
+ */
+"use client";
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function RootCodeRedirect({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const search = useSearchParams();
+  const code = search.get("code");
+
+  useEffect(() => {
+    if (code) {
+      router.replace(`/auth/callback?code=${code}`);
+    }
+  }, [code, router]);
+
+  return <>{children}</>;
+}

--- a/my-app/lib/auth.tsx
+++ b/my-app/lib/auth.tsx
@@ -322,6 +322,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           data: {
             full_name: fullName,
           },
+          emailRedirectTo: `${window.location.origin}/auth/callback`
         },
       });
 

--- a/my-app/lib/supabase/server.ts
+++ b/my-app/lib/supabase/server.ts
@@ -4,9 +4,12 @@ import { cookies } from "next/headers";
 /**
  * Creates a Supabase client for server-side operations.
  * Uses Next.js cookies() API for session management.
+ * 
+ * NOTE (Next 15 +): cookies() is now asynchronous in Route Handlers,
+ * so this helper itself must be async when you call it there.
  */
-export function createClient() {
-  const cookieStore = cookies();
+export async function createClient() {
+  const cookieStore = await cookies();
   
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
List of changes made:
• Add auth/callback page to exchange ?code= for session
• RootCodeRedirect shim forwards /?code= to /auth/callback until Supabase redirects list is updated
• Waiting page listens for SIGNED_IN events for instant redirect
• signUp now sets emailRedirectTo to /auth/callback
• createClient helper is async
• profile-status route awaits createClient

Requires Supabase admin:
add the following to redirect URLs (if possible)
http://localhost:3000/auth/callback < this is for local testing
https://aggie-nexus-mvp.vercel.app/auth/callback < this is the redirect link
to Auth ▸ Settings ▸ Redirect URLs.
After that we can remove app/root-code-redirect.tsx and its wrapper in layout.tsx.