### PR TITLE
Improve email-verification flow & profile-setup UX

### DIFF
--- a/my-app/app/auth/verified/page.tsx
+++ b/my-app/app/auth/verified/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { CheckCircle } from 'lucide-react'
+import { createClient } from '@/lib/supabase/client'
+
+export default function EmailVerifiedPage() {
+  // let the “waiting” tab know we’re done
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('emailVerified', 'true')
+      sessionStorage.removeItem('awaitingVerification')
+    }
+    const supabase = createClient()
+    supabase.auth.getSession().catch(() => {
+        
+    })
+  }, [])
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-8 text-center">
+      <CheckCircle className="h-12 w-12 text-green-500 mb-4" />
+      <h1 className="text-2xl font-bold mb-6">
+        Your account has been verified!
+      </h1>
+
+      <Link
+        href="/auth/login"
+        className="px-6 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition"
+      >
+        Click here to return to the login page
+      </Link>
+    </div>
+  )
+}

--- a/my-app/app/auth/waiting/page.tsx
+++ b/my-app/app/auth/waiting/page.tsx
@@ -3,27 +3,52 @@
 import { useState, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/lib/auth"
-import { Alert, AlertDescription } from "@/components/ui/alert"
+import {
+  Alert,
+  AlertDescription
+} from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
-import { Loader2, Mail, AlertCircle, LogOut, Home, CheckCircle } from "lucide-react"
+import {
+  Loader2,
+  Mail,
+  AlertCircle,
+  LogOut,
+  Home,
+  CheckCircle
+} from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
 import Link from "next/link"
-import { motion, AnimatePresence, Variants, Transition } from "framer-motion"
-import type { AuthChangeEvent, Session } from "@supabase/supabase-js"
+import {
+  motion,
+  AnimatePresence,
+  Variants,
+  Transition
+} from "framer-motion"
+import type {
+  AuthChangeEvent,
+  Session
+} from "@supabase/supabase-js"
 import { Card, CardContent } from "@/components/ui/card"
+import { set } from "date-fns"
 
-// Maximum waiting time (2 minutes) in milliseconds
-const MAX_WAIT_TIME = 120000
+const MAX_WAIT_TIME = 120000 // 2 min
 
 export default function AuthWaitingPage() {
   const router = useRouter()
-  const { authUser, profile, isLoading, signOut } = useAuth()
-  const [message, setMessage] = useState("Please verify your email to continue...")
-  const [userEmail, setUserEmail] = useState<string | null>(null)
+  const { authUser, profile, signOut } = useAuth()
+
+  /* ─────────────────── Local state ─────────────────── */
+  const [message, setMessage] = useState(
+    "Please verify your email to continue..."
+  )
+  const [userEmail, setUserEmail] = useState<string | null>(
+    null
+  )
   const [resendLoading, setResendLoading] = useState(false)
   const [emailResent, setEmailResent] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [isRedirecting, setIsRedirecting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(
+    null
+  )
   const [isVerified, setIsVerified] = useState(false)
   const [timeoutExceeded, setTimeoutExceeded] = useState(false)
   const [elapsedTime, setElapsedTime] = useState(0)
@@ -31,110 +56,60 @@ export default function AuthWaitingPage() {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const [isChecking, setIsChecking] = useState(false)
 
-  // Initialize email from localStorage and set verification flag in sessionStorage
+  /* ───────────── First-mount initialisation ─────────── */
   useEffect(() => {
+    localStorage.removeItem("emailVerified") 
+    sessionStorage.setItem("awaitingVerification", "true")
+
     const storedEmail = localStorage.getItem("lastSignupEmail")
     if (storedEmail) {
       setUserEmail(storedEmail)
-      setMessage(`Please verify your email (${storedEmail}) to continue...`)
+      setMessage(
+        `Please verify your email (${storedEmail}) to continue...`
+      )
     }
-    
-    // Set verification flag in sessionStorage to handle tab redirection
-    sessionStorage.setItem("awaitingVerification", "true")
-    
-    // Set timeout to prevent endless waiting
+
     timeoutRef.current = setTimeout(() => {
       setTimeoutExceeded(true)
-      if (checkInterval.current) {
-        clearInterval(checkInterval.current)
-        checkInterval.current = null
-      }
+      if (checkInterval.current) clearInterval(checkInterval.current)
     }, MAX_WAIT_TIME)
-    
+
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-      }
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }
   }, [])
 
-    // ---------------------------------------------------------------------------
-  // NEW: instant reaction to any SIGNED_IN / TOKEN_REFRESHED event in *any* tab
-  // ---------------------------------------------------------------------------
+  /* ───────────── Auth-state listener (no UI change) ───────────── */
   useEffect(() => {
     const supabase = createClient()
-
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (event: AuthChangeEvent, session: Session | null) => {
-        if (
-          ["SIGNED_IN", "USER_UPDATED", "TOKEN_REFRESHED"].includes(event) &&
-          session?.user?.email_confirmed_at
-        ) {
-          setIsVerified(true)
-          setMessage("Email verified! Redirecting you...")
-          setIsRedirecting(true)
-
-          // stop the poller (if still running)
-          if (checkInterval.current) {
-            clearInterval(checkInterval.current)
-            checkInterval.current = null
-          }
-
-          // let other tabs (or a future session) know
-          localStorage.setItem("emailVerified", "true")
-          sessionStorage.removeItem("awaitingVerification")
-
-          // same UX delay as elsewhere
-          setTimeout(() => {
-            router.push(
-              profile && profile.bio && profile.skills?.length ? "/" : "/profile/setup"
-            )
-          }, 1500)
-        }
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange(
+      (_event: AuthChangeEvent, _session: Session | null) => {
+        
       }
     )
-
-    // clean up when component unmounts
     return () => subscription.unsubscribe()
-  }, [profile, router])
+  }, [])
 
-  // Handle manual verification check
+  /* ─────────── Manual “check verification” button ─────────── */
   const handleManualCheck = async () => {
     setIsChecking(true)
     try {
       const supabase = createClient()
-      const { data, error } = await supabase.auth.refreshSession()
-      
-      if (error) {
-        // Ignore AuthSessionMissingError as it's expected when session is being created
-        if (error.name !== "AuthSessionMissingError") {
-          console.error("Error refreshing session:", error)
-        } else {
-          setMessage("Please sign in first to verify your email")
-        }
-        return
-      }
-      
-      if (data.user?.email_confirmed_at) {
+      const { data } = await supabase.auth.getSession() 
+
+      if (
+        data.session?.user?.email_confirmed_at &&
+        data.session.user.email === userEmail 
+      ) {
+        localStorage.setItem("emailVerified", "true") 
         setIsVerified(true)
-        setMessage("Email verified! Redirecting you...")
-        setIsRedirecting(true)
-        
-        // Signal to other tabs that verification is complete
-        localStorage.setItem("emailVerified", "true")
-        
-        // Remove verification flag from sessionStorage
-        sessionStorage.removeItem("awaitingVerification")
-        
-        setTimeout(() => {
-          if (profile && profile.bio && profile.skills && profile.skills.length > 0) {
-            router.push("/")
-          } else {
-            router.push("/profile/setup")
-          }
-        }, 1500)
+        setMessage(
+          "Email verified! Click below to continue to profile setup."
+        )
       } else {
-        setMessage(`Email not verified yet. Please check your inbox.`)
+        setMessage("Email not verified yet. Please check your inbox.")
       }
     } catch (err) {
       console.error("Error checking verification:", err)
@@ -143,231 +118,130 @@ export default function AuthWaitingPage() {
     }
   }
 
-  // Set up polling to check verification status
+  /* ─────────── Polling + storage-event listener ─────────── */
   useEffect(() => {
     let startTime = Date.now()
-    let isMounted = true
-    
-    // Check for inbound verification from another tab
+    let mounted = true
+
     const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === "emailVerified" && e.newValue === "true" && isMounted) {
+      if (
+        e.key === "emailVerified" &&
+        e.newValue === "true" &&
+        mounted
+      ) {
         setIsVerified(true)
-        setMessage("Email verified! Redirecting you...")
-        setIsRedirecting(true)
-        
-        if (checkInterval.current) {
-          clearInterval(checkInterval.current)
-          checkInterval.current = null
-        }
-        
-        // Short delay then redirect
-        setTimeout(() => {
-          router.push(profile && profile.bio && profile.skills?.length ? "/" : "/profile/setup")
-        }, 1500)
+        setMessage(
+          "Email verified! Click below to continue to profile setup."
+        )
       }
     }
-    
-    // Add storage listener for cross-tab communication
+
     window.addEventListener("storage", handleStorageChange)
-    
-    if (!authUser && !userEmail) {
-      // If no user and no email, redirect to login
-      router.push("/auth/login")
-      return () => {
-        window.removeEventListener("storage", handleStorageChange)
-      }
-    }
-    
-    // Get user email for display if available from user object
-    if (authUser && authUser.email && !userEmail) {
-      setUserEmail(authUser.email)
-    }
-    
-    // Function to check if email is verified
-    const checkEmailVerification = async () => {
-      // Update elapsed time for UI feedback
+
+    const poll = async () => {
       setElapsedTime(Math.floor((Date.now() - startTime) / 1000))
-      
       try {
         const supabase = createClient()
-        
-        // Refresh the session to get the latest user data
-        const { data, error } = await supabase.auth.refreshSession()
-        
-        if (error) {
-          // Ignore AuthSessionMissingError as it's expected when session is being created
-          if (error.name !== "AuthSessionMissingError") {
-            console.error("Error refreshing session:", error)
-          }
-          return
-        }
-        
-        // If email is confirmed, redirect based on profile status
-        if (data.user?.email_confirmed_at) {
+        const { data } = await supabase.auth.getSession() 
+
+        if (
+          data.session?.user?.email_confirmed_at &&
+          data.session.user.email === userEmail 
+        ) {
+          localStorage.setItem("emailVerified", "true") 
           setIsVerified(true)
-          setMessage("Email verified! Redirecting you...")
-          setIsRedirecting(true)
-          
-          // Clear the interval
-          if (checkInterval.current) {
-            clearInterval(checkInterval.current)
-            checkInterval.current = null
-          }
-          
-          // Signal to other tabs that verification is complete
-          localStorage.setItem("emailVerified", "true")
-          
-          // Remove verification flag from sessionStorage
-          sessionStorage.removeItem("awaitingVerification")
-          
-          // Check if profile is complete
-          setTimeout(() => {
-            if (profile && profile.bio && profile.skills && profile.skills.length > 0) {
-              router.push("/")
-            } else {
-              router.push("/profile/setup")
-            }
-          }, 1500) // Small delay for better UX
+          setMessage(
+            "Email verified! Click below to continue to profile setup."
+          )
         }
-      } catch (err) {
-        console.error("Error checking email verification:", err)
+      } catch {
+        /* ignore */
       }
     }
-    
-    // Check immediately and then set up interval
-    checkEmailVerification()
-    
-    // Set up interval to check every 3 seconds (slightly faster than before)
-    checkInterval.current = setInterval(checkEmailVerification, 3000)
-    
-    // Clean up on unmount
+
+    poll()
+    checkInterval.current = setInterval(poll, 3000)
+
     return () => {
-      isMounted = false
-      if (checkInterval.current) {
-        clearInterval(checkInterval.current)
-      }
+      mounted = false
+      if (checkInterval.current) clearInterval(checkInterval.current)
       window.removeEventListener("storage", handleStorageChange)
     }
-  }, [authUser, profile, router, userEmail])
+  }, [userEmail])
 
-  // Handle resend verification email
+  /* ─────────── Resend + sign-out helpers  ─────────── */
   const handleResendVerification = async () => {
-    // Try multiple sources for the email
-    const emailToUse = userEmail || authUser?.email;
-    
-    if (!emailToUse) {
-      setErrorMessage("Email address not found. Please sign up again.");
-      return;
-    }
-    
+    if (!userEmail) return
     try {
       setResendLoading(true)
       setErrorMessage(null)
-      
+
       const supabase = createClient()
       const { error } = await supabase.auth.resend({
-        type: 'signup',
-        email: emailToUse,
+        type: "signup",
+        email: userEmail,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
-        },
+          emailRedirectTo: `${window.location.origin}/auth/callback`
+        }
       })
-      
-      if (error) {
-        console.error("Resend error details:", error);
-        setErrorMessage(`Failed to resend email: ${error.message}`);
-      } else {
+
+      if (error) setErrorMessage(error.message)
+      else {
         setEmailResent(true)
-        setMessage(`Verification email resent to ${emailToUse}. Please check your inbox.`)
-        // Store the email in localStorage for future use
-        localStorage.setItem("lastSignupEmail", emailToUse);
+        setMessage(
+          `Verification email resent to ${userEmail}. Please check your inbox.`
+        )
       }
-    } catch (err) {
-      console.error("Failed to resend verification email:", err)
+    } catch {
       setErrorMessage("Failed to resend verification email. Please try again.")
     } finally {
       setResendLoading(false)
     }
   }
 
-  // Handle sign out
   const handleSignOut = async () => {
-    try {
-      // Remove verification flags
-      sessionStorage.removeItem("awaitingVerification")
-      localStorage.removeItem("emailVerified")
-      
-      await signOut()
-      // Clear local storage
-      localStorage.removeItem("lastSignupEmail")
-      // Redirect to home page after sign out
-      router.push("/")
-    } catch (err) {
-      console.error("Error signing out:", err)
-      setErrorMessage("Error signing out. Please try again.")
-    }
+    sessionStorage.removeItem("awaitingVerification")
+    localStorage.removeItem("emailVerified")
+    await signOut()
+    localStorage.removeItem("lastSignupEmail")
+    router.push("/")
   }
 
-  // Animation variants
+  /* ─────────── Animation helpers ─────────── */
   const containerVariants = {
     hidden: { opacity: 0 },
-    visible: { 
+    visible: {
       opacity: 1,
-      transition: { 
-        duration: 0.5,
-        when: "beforeChildren",
-        staggerChildren: 0.1
-      }
+      transition: { duration: 0.5, when: "beforeChildren", staggerChildren: 0.1 }
     },
     exit: { opacity: 0, transition: { duration: 0.3 } }
   }
-
   const itemVariants: Variants = {
     hidden: { y: 20, opacity: 0 },
-    visible: { 
-      y: 0, 
+    visible: {
+      y: 0,
       opacity: 1,
-      transition: { type: "spring", damping: 12 } as Transition,
-    },
+      transition: { type: "spring", damping: 12 } as Transition
+    }
   }
-
   const pulseVariants = {
     pulse: {
       scale: [1, 1.1, 1],
       opacity: [1, 0.8, 1],
-      transition: {
-        duration: 2,
-        repeat: Infinity,
-        repeatType: "loop" as const
-      }
+      transition: { duration: 2, repeat: Infinity, repeatType: "loop" as const }
     }
   }
 
-  const circleVariants = {
-    hidden: { pathLength: 0, opacity: 0 },
-    visible: { 
-      pathLength: 1, 
-      opacity: 1,
-      transition: { 
-        duration: 1.5,
-        ease: "easeInOut"
-      }
-    }
-  }
+  const getTimeMessage = () =>
+    elapsedTime < 30
+      ? "This usually takes less than a minute..."
+      : elapsedTime < 60
+      ? "Still waiting for verification..."
+      : "Taking longer than expected. Make sure to check your spam folder."
 
-  // Get a tailored message based on elapsed time
-  const getTimeMessage = () => {
-    if (elapsedTime < 30) {
-      return "This usually takes less than a minute..."
-    } else if (elapsedTime < 60) {
-      return "Still waiting for verification..."
-    } else {
-      return "Taking longer than expected. Make sure to check your spam folder."
-    }
-  }
-
+  /* ─────────── Render UI ─────────── */
   return (
-    <motion.div 
+    <motion.div
       className="container flex justify-center items-center min-h-[80vh] py-10"
       variants={containerVariants}
       initial="hidden"
@@ -375,8 +249,9 @@ export default function AuthWaitingPage() {
       exit="exit"
     >
       <AnimatePresence mode="wait">
+        {/* TIMEOUT CARD */}
         {timeoutExceeded ? (
-          <motion.div 
+          <motion.div
             className="w-full max-w-md"
             key="timeout"
             initial={{ opacity: 0 }}
@@ -386,15 +261,24 @@ export default function AuthWaitingPage() {
             <Card className="border-border/50 shadow-md">
               <CardContent className="pt-6 pb-6 text-center">
                 <AlertCircle className="h-12 w-12 text-amber-500 mx-auto mb-4" />
-                <h1 className="text-2xl font-bold mb-2">Verification Timeout</h1>
+                <h1 className="text-2xl font-bold mb-2">
+                  Verification Timeout
+                </h1>
                 <p className="text-muted-foreground mb-6">
                   We haven't detected your email verification yet. You can:
                 </p>
                 <div className="space-y-4">
-                  <Button className="w-full" onClick={handleResendVerification}>
+                  <Button
+                    className="w-full"
+                    onClick={handleResendVerification}
+                  >
                     Try Resending the Email
                   </Button>
-                  <Button variant="outline" className="w-full" onClick={handleSignOut}>
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={handleSignOut}
+                  >
                     Sign Out and Try Again Later
                   </Button>
                 </div>
@@ -402,7 +286,8 @@ export default function AuthWaitingPage() {
             </Card>
           </motion.div>
         ) : isVerified ? (
-          <motion.div 
+          /* VERIFIED CARD */
+          <motion.div
             className="w-full max-w-md"
             key="verified"
             initial={{ opacity: 0 }}
@@ -410,36 +295,37 @@ export default function AuthWaitingPage() {
             exit={{ opacity: 0 }}
           >
             <Card className="border-border/50 shadow-md overflow-hidden">
-              <motion.div 
-                className="h-2 bg-gradient-to-r from-green-400 to-emerald-500" 
+              <motion.div
+                className="h-2 bg-gradient-to-r from-green-400 to-emerald-500"
                 initial={{ width: 0 }}
                 animate={{ width: "100%" }}
                 transition={{ duration: 1 }}
               />
               <CardContent className="pt-6 pb-6 text-center">
-                <motion.div 
+                <motion.div
                   className="rounded-full p-2 bg-green-100 dark:bg-green-900/30 w-20 h-20 mx-auto mb-4 flex items-center justify-center"
                   animate={{ scale: [1, 1.1, 1] }}
                   transition={{ duration: 1, repeat: 1 }}
                 >
                   <CheckCircle className="h-10 w-10 text-green-500" />
                 </motion.div>
-                <h1 className="text-2xl font-bold mb-2">Email Verified!</h1>
+                <h1 className="text-2xl font-bold mb-4">Email Verified!</h1>
                 <p className="text-muted-foreground mb-6">
-                  Redirecting you to set up your profile...
+                  Great! Click below to continue to profile setup.
                 </p>
-                <motion.div 
-                  className="flex justify-center"
-                  animate={{ opacity: [0.5, 1, 0.5] }}
-                  transition={{ duration: 1.5, repeat: Infinity }}
+                <Button
+                  onClick={() =>
+                    (window.location.href = "/profile/setup") /* CHANGED */
+                  }
                 >
-                  <Loader2 className="h-6 w-6 text-primary animate-spin" />
-                </motion.div>
+                  Go to Profile Setup
+                </Button>
               </CardContent>
             </Card>
           </motion.div>
         ) : (
-          <motion.div 
+          /* WAITING CARD */
+          <motion.div
             className="w-full max-w-md"
             key="waiting"
             variants={containerVariants}
@@ -447,44 +333,49 @@ export default function AuthWaitingPage() {
             <Card className="border-border/50 shadow-md">
               <CardContent className="pt-6 pb-6 text-center">
                 <motion.div variants={itemVariants}>
-                  <motion.div 
+                  <motion.div
                     className="rounded-full p-3 bg-primary/10 w-24 h-24 mx-auto mb-4 flex items-center justify-center"
                     variants={pulseVariants}
                     animate="pulse"
                   >
                     <Mail className="h-12 w-12 text-primary" />
                   </motion.div>
-                  <h1 className="text-2xl font-bold mb-2">Verify Your Email</h1>
-                  <p className="text-muted-foreground mb-2">
-                    {message}
-                  </p>
+                  <h1 className="text-2xl font-bold mb-2">
+                    Verify Your Email
+                  </h1>
+                  <p className="text-muted-foreground mb-2">{message}</p>
                   <p className="text-sm text-muted-foreground mb-6">
                     {getTimeMessage()}
                   </p>
                   {userEmail && (
                     <p className="text-xs text-muted-foreground mb-4">
-                      💡 You'll need to verify your email before you can access all features.
+                      💡 You'll need to verify your email before you can access
+                      all features.
                     </p>
                   )}
                 </motion.div>
-                
+
                 {errorMessage && (
                   <motion.div variants={itemVariants}>
                     <Alert variant="destructive" className="mb-4">
                       <AlertCircle className="h-4 w-4" />
-                      <AlertDescription>{errorMessage}</AlertDescription>
+                      <AlertDescription>
+                        {errorMessage}
+                      </AlertDescription>
                     </Alert>
                   </motion.div>
                 )}
-                
+
                 <motion.div variants={itemVariants} className="space-y-4">
                   {!emailResent ? (
-                    <Button 
-                      onClick={handleResendVerification} 
-                      className="w-full" 
-                      disabled={resendLoading || (!userEmail && !authUser?.email)}
+                    <Button
+                      onClick={handleResendVerification}
+                      className="w-full"
+                      disabled={resendLoading || !userEmail}
                     >
-                      {resendLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                      {resendLoading && (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      )}
                       Resend Verification Email
                     </Button>
                   ) : (
@@ -494,34 +385,30 @@ export default function AuthWaitingPage() {
                       </AlertDescription>
                     </Alert>
                   )}
-                  
+
                   <div className="flex gap-4 mt-4">
-                    <Button 
-                      variant="outline" 
+                    <Button
+                      variant="outline"
                       className="flex-1"
                       onClick={handleSignOut}
                     >
                       <LogOut className="mr-2 h-4 w-4" />
                       Sign Out
                     </Button>
-                    
-                    <Button 
-                      variant="outline"
-                      className="flex-1"
-                      asChild
-                    >
+
+                    <Button variant="outline" className="flex-1" asChild>
                       <Link href="/">
                         <Home className="mr-2 h-4 w-4" />
                         Return Home
                       </Link>
                     </Button>
                   </div>
-                  
-                  <Button 
-                    onClick={handleManualCheck} 
-                    variant="secondary" 
-                    className="w-full mt-4" 
-                    disabled={isChecking || (!userEmail && !authUser?.email)}
+
+                  <Button
+                    onClick={handleManualCheck}
+                    variant="secondary"
+                    className="w-full mt-4"
+                    disabled={isChecking || !userEmail}
                   >
                     {isChecking ? (
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -531,25 +418,34 @@ export default function AuthWaitingPage() {
                     Check Verification Status
                   </Button>
                 </motion.div>
-                
-                <motion.div 
+
+                <motion.div
                   variants={itemVariants}
                   className="mt-8 text-sm text-muted-foreground"
                 >
                   <div className="flex justify-center mb-4">
                     <div className="relative h-1 w-32 bg-muted rounded-full overflow-hidden">
-                      <motion.div 
+                      <motion.div
                         className="absolute left-0 top-0 h-full bg-primary"
                         initial={{ width: "0%" }}
-                        animate={{ width: `${Math.min(100, (elapsedTime / (MAX_WAIT_TIME/1000)) * 100)}%` }}
+                        animate={{
+                          width: `${Math.min(
+                            100,
+                            (elapsedTime / (MAX_WAIT_TIME / 1000)) * 100
+                          )}%`
+                        }}
                         transition={{ duration: 0.5 }}
                       />
                     </div>
                   </div>
-                  
-                  <p>Once your email is verified, you'll be automatically redirected.</p>
+
+                  <p>
+                    Once your email is verified, you'll be automatically
+                    redirected.
+                  </p>
                   <p className="mt-2">
-                    Make sure to check your spam folder if you don't see the email.
+                    Make sure to check your spam folder if you don't see the
+                    email.
                   </p>
                 </motion.div>
               </CardContent>
@@ -559,4 +455,4 @@ export default function AuthWaitingPage() {
       </AnimatePresence>
     </motion.div>
   )
-} 
+}

--- a/my-app/app/profile/setup/page.tsx
+++ b/my-app/app/profile/setup/page.tsx
@@ -33,7 +33,8 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 export default function ProfileSetupPage() {
-  const { profile, refreshProfile, isLoading: authLoading } = useAuth();
+  const { authUser, profile, refreshProfile, isLoading: authLoading } = useAuth();
+  const stillLoadingProfile = authLoading || (authUser && !profile);
   const router = useRouter();
   const [isSaving, setIsSaving] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
@@ -309,7 +310,7 @@ export default function ProfileSetupPage() {
     }
   };
 
-  if (authLoading) {
+  if (stillLoadingProfile) {
     return (
       <div className="flex justify-center items-center min-h-[50vh]">
         <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -318,7 +319,7 @@ export default function ProfileSetupPage() {
     );
   }
 
-  if (!profile) {
+  if (!authUser) {
     return (
       <div className="container py-8">
         <Alert className="mb-6">
@@ -379,7 +380,7 @@ export default function ProfileSetupPage() {
             <TagSelector
               label="Industries"
               options={industryOptions}
-              selected={profile.industry || []}
+              selected={profile?.industry || []}
               onChange={setSelectedIndustries}
             />
           </div>
@@ -388,7 +389,7 @@ export default function ProfileSetupPage() {
             <TagSelector
               label="Skills"
               options={skillOptions}
-              selected={profile.skills || []}
+              selected={profile?.skills || []}
               onChange={setSelectedSkills}
               maxTags={15}
             />


### PR DESCRIPTION
After users signed up, the “Please verify your e-mail” screen was flakey. Sometimes it jumped straight to “Verified” even when nothing was verified yet. Other times it kept spinning forever and you had to refresh manually. The e-mail link dropped people into profile setup too early, which was confusing.

These changes do the following:

/auth/waiting page: (Mostly overhauled)
1) Shows a proper waiting screen until your e-mail is confirmed
2) Checks every 3 secondsish
3) When you ARE verified it will show a green card with one big button that takes you to the profile set-up screen.

- Note: The old page listened for supabase signed in token refreshed to guess when the email was confirmed, which instantly flipped the "green verified card" on the original tab that sent the email, because of this it created false positive issues and an infinite loading issue, two tabs would be "fighting" over who had the real session prodcuing these random errors, with the new page it confirms that the re-direct is the "real" session and we should be utilizing that hence the new button to refresh to profile/setup instead of an automatic redirect.

/auth/verified is NEW
1) Simple page you land onafter clicking the link in the verification email, it briefly shows you've verified your email and redirects you to profile/setup almost immediately. (This is seperate from the original page where the email verification was sent.)

/auth/callback/route.ts
1) Now recognizes a pure e-mail confirmed visit and sends you to the new confirmation page instead of profile setup immediately, so that nothing loads before it should. (This is for the original page that SENDS the verification link not the verification re-direct.)

/profile/setup
1) Added a tiny "Please wait" guard so it doesnt flash you need to login while the profile is still loading.