### PR TITLE
Fix: switch middleware to Node.js runtime

### DIFF
--- a/my-app/middleware.ts
+++ b/my-app/middleware.ts
@@ -1,9 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
-// Middleware only does fast cookie-presence routing.
-// Full auth verification (getUser, session validation) happens in server components
-// where Node.js APIs are available. The Edge Runtime cannot run the Supabase SDK
-// because @supabase/realtime-js uses process.versions, a Node.js-only API.
+// Run on Node.js runtime (not Edge) so Vercel's V8 isolate restrictions don't apply.
+// Next.js 15.1+ supports nodejs middleware via the runtime export below.
+export const runtime = 'nodejs';
 
 const PUBLIC_ROUTES = [
   '/',


### PR DESCRIPTION
## What

Add `export const runtime = 'nodejs'` to `middleware.ts`.

## Why

`MIDDLEWARE_INVOCATION_FAILED` on every request — the Edge Runtime (V8 isolate) was crashing the middleware before it could execute a single line, even on public routes like `/auth/login`.

Root cause: Next.js's Vercel Edge Runtime has restrictions that cause our middleware bundle to crash at initialization. I traced through `node_modules/next/dist/build/index.js` and confirmed that when `staticInfo.runtime === 'nodejs'`, Next.js compiles the middleware as a standard Node.js function (`loadNodeMiddleware()`) instead of an edge bundle — completely sidestepping the V8 isolate.

This is a supported Next.js 15.1+ feature, available in our 15.5.18 build.

## Test plan
- [ ] Vercel build passes
- [ ] `accelerator.aggiex.org` loads (no 500)
- [ ] Unauthenticated users redirect to `/auth/login`
- [ ] Authenticated users can reach the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)