### PR TITLE
Fix: Edge Runtime + native Response (no __dirname, no broken routing)

### DIFF
--- a/my-app/middleware.ts
+++ b/my-app/middleware.ts
@@ -1,9 +1,10 @@
 import type { NextRequest } from 'next/server';
 
-// Run on Node.js runtime — avoids Edge Runtime V8 isolate restrictions.
-// All responses use the native Response class with Next.js internal headers
-// so no next/server classes are bundled, eliminating the __dirname cold-start crash.
-export const runtime = 'nodejs';
+// Edge Runtime (default). No next/server classes are imported at runtime —
+// only native Response/Headers/URL — so no __dirname or process.versions
+// references are bundled. The middleware-manifest.json is populated correctly
+// for Vercel's CDN routing (Node.js runtime breaks this by writing to
+// functions-config-manifest.json instead, which Vercel's edge layer ignores).
 
 const PUBLIC_ROUTES = [
   '/',


### PR DESCRIPTION
## What

Remove `export const runtime = 'nodejs'` — go back to Edge Runtime.

## Why Node.js runtime caused NOT_FOUND

With `runtime = 'nodejs'`, Next.js writes middleware metadata to `functions-config-manifest.json` instead of `middleware-manifest.json`. Vercel's CDN routing layer reads `middleware-manifest.json`; finding it empty, Vercel returns `NOT_FOUND` for every request before the app even starts.

## Why Edge Runtime is now safe

The previous Edge Runtime failures were caused by `next/server` classes being bundled:
- `NextResponse` → `next/server` → `@supabase/realtime-js` → `process.versions` crash
- `NextResponse` also bundled code with `__dirname` references

Both are eliminated: `import type { NextRequest }` is erased at compile time. All responses use the **native `Response` class** with Next.js's internal protocol headers (`x-middleware-next: 1`, `Location`). The Edge Runtime bundle now contains only our code + native web APIs — no Node.js dependencies at all.

## Test plan
- [ ] `/_next/static/` returns 200 (was returning 404 — proves routing is fixed)
- [ ] `accelerator.aggiex.org` loads
- [ ] No `__dirname` or `MIDDLEWARE_INVOCATION_FAILED` errors
- [ ] Auth redirects work

🤖 Generated with [Claude Code](https://claude.com/claude-code)