### PR TITLE
Add Render deployment + fix start port

### DIFF
--- a/my-app/package.json
+++ b/my-app/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p ${PORT:-3000}",
     "lint": "next lint"
   },
   "dependencies": {

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  - type: web
+    name: aggiex-accelerator
+    runtime: node
+    rootDir: my-app
+    buildCommand: npm install && npm run build
+    startCommand: npm start
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: NEXT_PUBLIC_SUPABASE_URL
+        sync: false
+      - key: NEXT_PUBLIC_SUPABASE_ANON_KEY
+        sync: false
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        sync: false
+      - key: RESEND_API_KEY
+        sync: false
+      - key: EMAIL_FROM
+        sync: false
+      - key: NEXT_PUBLIC_SITE_URL
+        sync: false


### PR DESCRIPTION
Switching from Vercel to Render to bypass Vercel's global domain ownership conflict (aggiex.org is registered in another Vercel account, blocking subdomain assignment).

## Changes
- `render.yaml` — auto-configures Render web service (rootDir: my-app, build/start commands, env var stubs)
- `package.json` start script — `next start -p ${PORT:-3000}` so Render's \$PORT env var is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)