### PR TITLE
fix: SameSite=None for PKCE verifier + replace requestUrl.origin in c…

### DIFF
--- a/my-app/app/auth/callback/route.ts
+++ b/my-app/app/auth/callback/route.ts
@@ -33,36 +33,44 @@ export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
   const type = requestUrl.searchParams.get('type')
-  
-  callbackLog("Auth callback initiated", { 
-    hasCode: !!code, 
-    origin: requestUrl.origin 
+
+  // Build the public-facing origin from headers.
+  // On Render, request.url is the internal process URL (https://localhost:10000/...)
+  // so publicOrigin would send all redirects to localhost. The host header
+  // always carries the real public hostname; x-forwarded-proto carries the protocol.
+  const host = request.headers.get('host') ?? ''
+  const proto = request.headers.get('x-forwarded-proto')?.split(',')[0].trim() ?? 'https'
+  const publicOrigin = `${proto}://${host}`
+
+  callbackLog("Auth callback initiated", {
+    hasCode: !!code,
+    publicOrigin,
   });
-  
+
   // If no code provided, redirect to home page
   if (!code) {
     callbackLog("No auth code provided, redirecting to home");
-    return NextResponse.redirect(new URL('/', requestUrl.origin))
+    return NextResponse.redirect(new URL('/', publicOrigin))
   }
 
   try {
     const supabase = await createClient()
-    
+
     callbackLog("Exchanging code for session");
-    // Exchange the code for a session 
+    // Exchange the code for a session
     const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
-    
+
     if (exchangeError) {
       callbackError("Code exchange failed", exchangeError);
       return NextResponse.redirect(
-        new URL(`/auth/login?error=${encodeURIComponent(exchangeError.message)}`, requestUrl.origin)
+        new URL(`/auth/login?error=${encodeURIComponent(exchangeError.message)}`, publicOrigin)
       )
     }
 
     // Handle password recovery flow
     if (type === 'recovery') {
       callbackLog('Password recovery callback detected, redirecting to reset password page');
-      return NextResponse.redirect(new URL('/auth/reset-password', requestUrl.origin))
+      return NextResponse.redirect(new URL('/auth/reset-password', publicOrigin))
     }
 
     if (type === 'signup' || type === 'invite') {
@@ -110,7 +118,7 @@ export async function GET(request: NextRequest) {
             .maybeSingle()
 
           if (accelProfile) {
-            const accelOrigin = process.env.ACCEL_URL ?? requestUrl.origin
+            const accelOrigin = process.env.ACCEL_URL ?? publicOrigin
             if (!accelProfile.onboarding_completed_at) {
               callbackLog('Accelerator invite — redirecting to onboarding')
               return NextResponse.redirect(new URL('/accelerator/onboarding', accelOrigin))
@@ -125,7 +133,7 @@ export async function GET(request: NextRequest) {
         }
       }
 
-      return NextResponse.redirect(new URL('/auth/verified', requestUrl.origin))
+      return NextResponse.redirect(new URL('/auth/verified', publicOrigin))
     }
 
     callbackLog("Code exchange successful, retrieving user session");
@@ -134,7 +142,7 @@ export async function GET(request: NextRequest) {
     
     if (userError || !user) {
       callbackError("Failed to retrieve user after code exchange", userError);
-      return NextResponse.redirect(`${requestUrl.origin}/?auth_error=callback_failed`)
+      return NextResponse.redirect(`${publicOrigin}/?auth_error=callback_failed`)
     }
     
     callbackLog("User session established", {
@@ -146,7 +154,7 @@ export async function GET(request: NextRequest) {
     // Check email verification status first
     if (!user.email_confirmed_at) {
       callbackLog("User email not verified, redirecting to waiting page");
-      return NextResponse.redirect(new URL('/auth/waiting', requestUrl.origin))
+      return NextResponse.redirect(new URL('/auth/waiting', publicOrigin))
     }
     
     // After OAuth login, check/create user profile and determine redirect
@@ -209,7 +217,7 @@ export async function GET(request: NextRequest) {
         callbackLog('OAuth login — accel_profile found, routing into accelerator')
         // Always redirect accelerator users to the accelerator domain, even if
         // this callback was reached via www.aggiex.org (Supabase Site URL fallback).
-        const accelOrigin = process.env.ACCEL_URL ?? requestUrl.origin
+        const accelOrigin = process.env.ACCEL_URL ?? publicOrigin
         if (!accelProfile.onboarding_completed_at) {
           return NextResponse.redirect(new URL('/accelerator/onboarding', accelOrigin))
         }
@@ -249,10 +257,10 @@ export async function GET(request: NextRequest) {
         // Redirect based on profile status
         if (status.shouldSetupProfile) {
           callbackLog("Profile setup needed, redirecting to setup");
-          return NextResponse.redirect(new URL('/profile/setup', requestUrl.origin))
+          return NextResponse.redirect(new URL('/profile/setup', publicOrigin))
         } else {
           callbackLog("Profile complete, redirecting to home");
-          return NextResponse.redirect(new URL('/', requestUrl.origin))
+          return NextResponse.redirect(new URL('/', publicOrigin))
         }
       } else {
         // The user doesn't exist in the users table yet, create them
@@ -291,17 +299,17 @@ export async function GET(request: NextRequest) {
         
         // New users always need to complete profile setup
         callbackLog("New user created, redirecting to profile setup");
-        return NextResponse.redirect(new URL('/profile/setup', requestUrl.origin))
+        return NextResponse.redirect(new URL('/profile/setup', publicOrigin))
       }
     } catch (err) {
       callbackError("Error in user profile check", err);
       // On error, default to redirecting to the home page
-      return NextResponse.redirect(new URL('/', requestUrl.origin))
+      return NextResponse.redirect(new URL('/', publicOrigin))
     }
   } catch (err) {
     callbackError("Auth callback exception", err);
     return NextResponse.redirect(
-      new URL('/auth/login?error=Authentication+failed', requestUrl.origin)
+      new URL('/auth/login?error=Authentication+failed', publicOrigin)
     )
   }
 } 

--- a/my-app/lib/supabase/server.ts
+++ b/my-app/lib/supabase/server.ts
@@ -52,19 +52,21 @@ export async function createClient() {
           set(name: string, value: string, options: CookieOptions = {}) {
             serverLog("Cookie set", { name });
             try {
+              // PKCE code-verifier cookies must use SameSite=None so Safari stores
+              // them when the Set-Cookie arrives on the same response that immediately
+              // redirects cross-site to Google. Safari drops SameSite=Lax cookies in
+              // that scenario; Chrome does not. Without None, Safari falls back to a
+              // stale verifier → "code challenge does not match previously saved code
+              // verifier". Session/auth cookies keep SameSite=Lax (CSRF protection).
+              const isPkceVerifier = name.includes('code-verifier')
               cookieStore.set({
                 name,
                 value,
                 ...options,
                 domain: SHARED_COOKIE_DOMAIN,
                 httpOnly: options.httpOnly ?? true,
-                // Always Secure: both production and the local dev server run on HTTPS
-                // (https://localhost:10000). Without Secure, Safari rejects or mishandles
-                // cookies set on HTTPS pages during cross-site redirects (the OAuth PKCE
-                // flow), causing "code challenge does not match previously saved code
-                // verifier". Chrome is lenient; Safari is not.
-                secure: options.secure ?? true,
-                sameSite: options.sameSite ?? 'lax',
+                secure: true,
+                sameSite: isPkceVerifier ? 'none' : (options.sameSite ?? 'lax'),
                 path: options.path ?? '/'
               });
             } catch (error) {
@@ -74,6 +76,7 @@ export async function createClient() {
           remove(name: string, options: CookieOptions = {}) {
             serverLog("Cookie remove", { name });
             try {
+              const isPkceVerifier = name.includes('code-verifier')
               cookieStore.set({
                 name,
                 value: '',
@@ -81,6 +84,8 @@ export async function createClient() {
                 domain: SHARED_COOKIE_DOMAIN,
                 expires: new Date(0),
                 maxAge: 0,
+                secure: true,
+                sameSite: isPkceVerifier ? 'none' : (options.sameSite ?? 'lax'),
                 path: options.path ?? '/'
               });
             } catch (error) {


### PR DESCRIPTION
…allback

Two bugs:

1. Safari drops SameSite=Lax cookies set on the same response that immediately redirects cross-site. When /auth/oauth returns Set-Cookie (verifier) + Location: accounts.google.com, Safari discards the cookie. On the return trip it falls back to a stale verifier → "code challenge does not match previously saved code verifier". Chrome stores it fine.

   Fix: use SameSite=None for cookies whose name contains 'code-verifier' (the PKCE verifier). Session/auth cookies keep SameSite=Lax. Apply the same attribute in the remove() callback so deletion works correctly.

2. All redirects in /auth/callback used requestUrl.origin which is https://localhost:10000 on Render (internal process URL, not the public hostname). Chrome never hit the error path (PKCE succeeded) so this was invisible. Safari always hit it → error URL showed localhost.

   Fix: derive publicOrigin from host + x-forwarded-proto headers (same pattern already applied to /auth/oauth) and replace all requestUrl.origin usages in the callback.