### PR TITLE
fix: restore mobile readability on landing page

### DIFF
--- a/my-app/app/_caneckt-landing.tsx
+++ b/my-app/app/_caneckt-landing.tsx
@@ -207,7 +207,7 @@ export default function CanecktLandingPage() {
 
   return (
     <div
-      className={`${spaceGrotesk.variable} h-screen flex flex-col overflow-hidden`}
+      className={`${spaceGrotesk.variable} relative min-h-screen flex flex-col overflow-x-hidden`}
       style={{
         background: '#030308',
         backgroundImage: 'radial-gradient(rgba(255,255,255,0.055) 1px, transparent 1px)',
@@ -239,7 +239,7 @@ export default function CanecktLandingPage() {
       </motion.header>
 
       {/* ── Two-column layout ── */}
-      <main className="relative z-10 flex-1 min-h-0 flex flex-col lg:flex-row">
+      <main className="relative z-10 flex-1 flex flex-col lg:flex-row">
 
         {/* Left: wordmark + descriptor */}
         <div className="flex-1 flex flex-col justify-center px-8 md:px-14 lg:px-20 xl:px-28 pt-8 pb-10 lg:py-0">
@@ -259,7 +259,7 @@ export default function CanecktLandingPage() {
             className="font-extrabold leading-none tracking-tighter mb-6"
             style={{
               fontFamily: 'var(--font-space-grotesk, sans-serif)',
-              fontSize: 'clamp(4.5rem, 13vw, 10rem)',
+              fontSize: 'clamp(2.5rem, 13vw, 10rem)',
               background: 'linear-gradient(145deg, #ffffff 0%, #c8c8d8 55%, #5a5a7a 100%)',
               WebkitBackgroundClip: 'text',
               WebkitTextFillColor: 'transparent',

--- a/my-app/app/layout.tsx
+++ b/my-app/app/layout.tsx
@@ -3,18 +3,18 @@ import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AuthProvider } from "@/lib/auth";
 import type { Metadata, Viewport } from "next";
+import ClientLayout from "@/components/client-layout";
+import ConditionalNavbar from "@/components/conditional-navbar";
+import { Toaster } from "@/components/ui/sonner";
+import RootCodeRedirect from "./root-code-redirect";
+import AuthDebug from "@/components/auth-debug";
+import AuthStateSync from "../components/auth-state-sync";
+import { Analytics } from "@vercel/analytics/next";
 
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
 };
-import ClientLayout from "@/components/client-layout";
-import ConditionalNavbar from "@/components/conditional-navbar";
-import { Toaster } from "@/components/ui/sonner";
-import RootCodeRedirect from "./root-code-redirect"; // already imported
-import AuthDebug from "@/components/auth-debug"; // Import the debug component
-import AuthStateSync from "../components/auth-state-sync";
-import { Analytics } from "@vercel/analytics/next";
 
 const inter = Inter({ subsets: ["latin"] });
 


### PR DESCRIPTION
- Move viewport export to after all imports in layout.tsx (was illegally placed mid-import-block, breaking module parse order)
- Landing page: h-screen overflow-hidden → min-h-screen overflow-x-hidden so the stacked mobile layout can scroll rather than clipping the sign-in form
- Remove min-h-0 on main (only needed with a fixed h-screen parent)
- Add relative to root div so OrbitalRings are contained within the page
- Reduce heading clamp minimum: 4.5rem → 2.5rem so the title fits on small screens