### PR TITLE
fix: correct AXR origin to axr-live + add framework-level CORS headers

### DIFF
--- a/my-app/app/api/accelerator/magic-link/route.ts
+++ b/my-app/app/api/accelerator/magic-link/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { createAdminClient } from '@/lib/supabase/accel-admin';
 import { emailService } from '@/lib/email';
 
-const AXR_ORIGIN = 'https://axr-1.onrender.com';
+const AXR_ORIGIN = 'https://axr-live.onrender.com';
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': AXR_ORIGIN,

--- a/my-app/next.config.mjs
+++ b/my-app/next.config.mjs
@@ -1,5 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/api/accelerator/magic-link',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: 'https://axr-live.onrender.com' },
+          { key: 'Access-Control-Allow-Methods', value: 'POST, OPTIONS' },
+          { key: 'Access-Control-Allow-Headers', value: 'Content-Type' },
+        ],
+      },
+    ];
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
CORS header was set to axr-1.onrender.com (incorrect subdomain) instead of axr-live.onrender.com. Also added headers() in next.config.mjs so CORS headers attach at the framework level, covering any trailing-slash redirects before the route handler runs.