### PR TITLE
fix: cross-platform MCP config + add update_aggiex_mcp self-update tool

### DIFF
--- a/mcp-server/AGENT_INSTRUCTIONS.md
+++ b/mcp-server/AGENT_INSTRUCTIONS.md
@@ -1,0 +1,105 @@
+# AggieX MCP — Agent Instructions
+
+**Version:** 0.1.1
+**Updated:** 2026-06-02
+
+This file is fetched live by the `update_aggiex_mcp` tool. Call it whenever you are unsure about your configuration, encounter connection errors, or want to check if a server update is available.
+
+---
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `update_aggiex_mcp` | Fetch this file — latest instructions and version |
+| `get_team_status` | Team name, current program week, submission progress |
+| `get_pending_deliverables` | Deliverables not yet submitted or needing revision |
+| `submit_deliverable(deliverable_id, text_content)` | Submit a written response for a deliverable |
+| `log_traction(metric_type, value, unit, notes?)` | Log a metric: users, revenue, LOIs, pilots, retention, churn |
+| `get_traction_history` | View recent traction log entries |
+
+---
+
+## Setup
+
+### macOS / Linux
+
+**1. Install (run once in Terminal):**
+```bash
+mkdir -p ~/.aggiex && curl -fsSL https://raw.githubusercontent.com/vivek-somarapu/aggie_nexus_mvp/main/mcp-server/dist/index.js -o ~/.aggiex/server.js && chmod +x ~/.aggiex/server.js
+```
+
+**2. Add to `.claude/settings.json`:**
+```json
+{
+  "mcpServers": {
+    "aggiex": {
+      "command": "/bin/bash",
+      "args": ["-lc", "node ~/.aggiex/server.js"],
+      "env": {
+        "AGGIEX_API_KEY": "YOUR_KEY",
+        "AGGIEX_BASE_URL": "https://accelerator.aggiex.org"
+      }
+    }
+  }
+}
+```
+
+> **Why `/bin/bash -lc`?** Claude Code spawns the MCP process directly — it does not go through a shell, so `~` and your PATH (including Homebrew Node) would not be available. The `-l` flag loads your login profile so Node is on PATH; `-c` runs the command through bash so `~` expands correctly.
+
+---
+
+### Windows
+
+**1. Install (run once in PowerShell):**
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.aggiex"; Invoke-WebRequest -Uri "https://raw.githubusercontent.com/vivek-somarapu/aggie_nexus_mvp/main/mcp-server/dist/index.js" -OutFile "$env:USERPROFILE\.aggiex\server.js"
+```
+
+**2. Add to `.claude/settings.json`:**
+```json
+{
+  "mcpServers": {
+    "aggiex": {
+      "command": "cmd.exe",
+      "args": ["/c", "node %USERPROFILE%\\.aggiex\\server.js"],
+      "env": {
+        "AGGIEX_API_KEY": "YOUR_KEY",
+        "AGGIEX_BASE_URL": "https://accelerator.aggiex.org"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Proactive Usage
+
+- **Session start:** call `get_team_status` and `get_pending_deliverables` to understand what is outstanding
+- **User mentions metrics** ("we hit 200 users", "closed an LOI", "$5k MRR"): offer to `log_traction`
+- **Work completes on something matching a deliverable:** offer to `submit_deliverable`
+- **Connection errors or config issues:** call `update_aggiex_mcp` for the latest troubleshooting guidance
+- Always confirm with the user before submitting or logging anything
+
+---
+
+## Updating the Server
+
+Re-run the install command for your platform above to pull the latest binary. After re-running, restart Claude Code (or reload MCP servers) to pick up the new version.
+
+---
+
+## Troubleshooting
+
+**"AGGIEX_API_KEY environment variable is required"**
+→ The `env` block in your settings.json is missing or the key is empty. Generate a new key at `https://accelerator.aggiex.org/accelerator/my-team/developer`.
+
+**"spawn /bin/bash ENOENT" or node not found**
+→ Try replacing `/bin/bash` with `/bin/zsh` (macOS default since Catalina). Or find your node path with `which node` in Terminal and use it directly: `"args": ["-lc", "/usr/local/bin/node ~/.aggiex/server.js"]`.
+
+**"HTTP 401" or "HTTP 403"**
+→ Your API key has been revoked or is invalid. Generate a new one at the Developer API page and update your settings.json.
+
+**Server connects but tools return errors**
+→ Verify `AGGIEX_BASE_URL` is set to `https://accelerator.aggiex.org` (no trailing slash).

--- a/mcp-server/dist/index.js
+++ b/mcp-server/dist/index.js
@@ -15456,6 +15456,7 @@ var StdioServerTransport = class {
 // src/index.ts
 var API_KEY = process.env.AGGIEX_API_KEY;
 var BASE_URL = (process.env.AGGIEX_BASE_URL ?? "https://accelerator.aggiex.org").replace(/\/$/, "");
+var INSTRUCTIONS_URL = "https://raw.githubusercontent.com/vivek-somarapu/aggie_nexus_mvp/main/mcp-server/AGENT_INSTRUCTIONS.md";
 if (!API_KEY) {
   console.error("AGGIEX_API_KEY environment variable is required.");
   process.exit(1);
@@ -15483,11 +15484,16 @@ async function apiFetch(path, options = {}) {
   return data;
 }
 var server = new Server(
-  { name: "aggiex-mcp", version: "0.1.0" },
+  { name: "aggiex-mcp", version: "0.1.1" },
   { capabilities: { tools: {} } }
 );
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
+    {
+      name: "update_aggiex_mcp",
+      description: "Fetch the latest AggieX MCP setup instructions and version notes. Call this whenever you are unsure about configuration, encounter errors, or want to check if the server needs to be updated.",
+      inputSchema: { type: "object", properties: {}, required: [] }
+    },
     {
       name: "get_team_status",
       description: "Get your team name, current program week, and overall submission progress.",
@@ -15548,6 +15554,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
   try {
+    if (name === "update_aggiex_mcp") {
+      const response = await fetch(INSTRUCTIONS_URL);
+      if (!response.ok) throw new Error(`Failed to fetch instructions: HTTP ${response.status}`);
+      const instructions = await response.text();
+      return { content: [{ type: "text", text: instructions }] };
+    }
     if (name === "get_team_status") {
       const me = await apiFetch("/api/accelerator/me");
       const lines = [
@@ -15626,7 +15638,9 @@ ${lines.join("\n")}` }]
       if (!entries?.length) {
         return { content: [{ type: "text", text: "No traction entries yet." }] };
       }
-      const lines = entries.slice(0, 20).map((e) => `- ${e.entry_date}: ${e.value} ${e.unit} (${e.metric_type})${e.notes ? ` \u2014 ${e.notes}` : ""}`);
+      const lines = entries.slice(0, 20).map(
+        (e) => `- ${e.entry_date}: ${e.value} ${e.unit} (${e.metric_type})${e.notes ? ` \u2014 ${e.notes}` : ""}`
+      );
       return { content: [{ type: "text", text: lines.join("\n") }] };
     }
     return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -10,6 +10,9 @@ import {
 const API_KEY = process.env.AGGIEX_API_KEY;
 const BASE_URL = (process.env.AGGIEX_BASE_URL ?? 'https://accelerator.aggiex.org').replace(/\/$/, '');
 
+const INSTRUCTIONS_URL =
+  'https://raw.githubusercontent.com/vivek-somarapu/aggie_nexus_mvp/main/mcp-server/AGENT_INSTRUCTIONS.md';
+
 if (!API_KEY) {
   console.error('AGGIEX_API_KEY environment variable is required.');
   process.exit(1);
@@ -33,21 +36,30 @@ async function apiFetch(path: string, options: RequestInit = {}): Promise<unknow
     data = text;
   }
   if (!response.ok) {
-    const errorMessage = typeof data === 'object' && data !== null && 'error' in data
-      ? (data as { error: string }).error
-      : `HTTP ${response.status}`;
+    const errorMessage =
+      typeof data === 'object' && data !== null && 'error' in data
+        ? (data as { error: string }).error
+        : `HTTP ${response.status}`;
     throw new Error(errorMessage);
   }
   return data;
 }
 
 const server = new Server(
-  { name: 'aggiex-mcp', version: '0.1.0' },
+  { name: 'aggiex-mcp', version: '0.1.1' },
   { capabilities: { tools: {} } }
 );
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
+    {
+      name: 'update_aggiex_mcp',
+      description:
+        'Fetch the latest AggieX MCP setup instructions and version notes. ' +
+        'Call this whenever you are unsure about configuration, encounter errors, ' +
+        'or want to check if the server needs to be updated.',
+      inputSchema: { type: 'object', properties: {}, required: [] },
+    },
     {
       name: 'get_team_status',
       description: 'Get your team name, current program week, and overall submission progress.',
@@ -100,7 +112,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'get_traction_history',
-      description: 'Get your team\'s recent traction entries.',
+      description: "Get your team's recent traction entries.",
       inputSchema: { type: 'object', properties: {}, required: [] },
     },
   ],
@@ -110,6 +122,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
   try {
+    if (name === 'update_aggiex_mcp') {
+      const response = await fetch(INSTRUCTIONS_URL);
+      if (!response.ok) throw new Error(`Failed to fetch instructions: HTTP ${response.status}`);
+      const instructions = await response.text();
+      return { content: [{ type: 'text', text: instructions }] };
+    }
+
     if (name === 'get_team_status') {
       const me = await apiFetch('/api/accelerator/me') as {
         full_name: string;
@@ -156,8 +175,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return { content: [{ type: 'text', text: 'All deliverables submitted!' }] };
       }
 
-      const lines = pending.map((d) =>
-        `- [${d.id}] ${d.title} (${d.expected_format}${d.is_required ? ', required' : ''})\n  ${d.description ?? ''}`
+      const lines = pending.map(
+        (d) =>
+          `- [${d.id}] ${d.title} (${d.expected_format}${d.is_required ? ', required' : ''})\n  ${d.description ?? ''}`
       );
       return {
         content: [{ type: 'text', text: `Pending deliverables:\n${lines.join('\n')}` }],
@@ -231,7 +251,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       const lines = entries
         .slice(0, 20)
-        .map((e) => `- ${e.entry_date}: ${e.value} ${e.unit} (${e.metric_type})${e.notes ? ` — ${e.notes}` : ''}`);
+        .map(
+          (e) =>
+            `- ${e.entry_date}: ${e.value} ${e.unit} (${e.metric_type})${e.notes ? ` — ${e.notes}` : ''}`
+        );
       return { content: [{ type: 'text', text: lines.join('\n') }] };
     }
 

--- a/my-app/app/accelerator/(platform)/my-team/developer/components/developer-panel.tsx
+++ b/my-app/app/accelerator/(platform)/my-team/developer/components/developer-panel.tsx
@@ -10,44 +10,52 @@ interface ApiKeyRow {
   created_at: string;
 }
 
-function buildFullPrompt(apiKey: string): string {
-  return `## AggieX MCP Setup
+type Platform = 'mac' | 'windows';
 
-### 1. Install
+const INSTALL_COMMANDS: Record<Platform, string> = {
+  mac: 'mkdir -p ~/.aggiex && curl -fsSL https://raw.githubusercontent.com/vivek-somarapu/aggie_nexus_mvp/main/mcp-server/dist/index.js -o ~/.aggiex/server.js && chmod +x ~/.aggiex/server.js',
+  windows:
+    'New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\\.aggiex"; Invoke-WebRequest -Uri "https://raw.githubusercontent.com/vivek-somarapu/aggie_nexus_mvp/main/mcp-server/dist/index.js" -OutFile "$env:USERPROFILE\\.aggiex\\server.js"',
+};
 
-Run in your terminal:
-
-\`\`\`bash
-mkdir -p ~/.aggiex && curl -fsSL https://raw.githubusercontent.com/vivek-somarapu/aggie_nexus_mvp/main/mcp-server/dist/index.js -o ~/.aggiex/server.js && chmod +x ~/.aggiex/server.js
-\`\`\`
-
-### 2. Configure
-
-Add to \`.claude/settings.json\`:
-
-\`\`\`json
-{
+function buildMcpConfig(apiKey: string, platform: Platform): string {
+  if (platform === 'windows') {
+    return `{
   "mcpServers": {
     "aggiex": {
-      "command": "node",
-      "args": ["~/.aggiex/server.js"],
+      "command": "cmd.exe",
+      "args": ["/c", "node %USERPROFILE%\\\\.aggiex\\\\server.js"],
       "env": {
         "AGGIEX_API_KEY": "${apiKey}",
         "AGGIEX_BASE_URL": "https://accelerator.aggiex.org"
       }
     }
   }
+}`;
+  }
+  return `{
+  "mcpServers": {
+    "aggiex": {
+      "command": "/bin/bash",
+      "args": ["-lc", "node ~/.aggiex/server.js"],
+      "env": {
+        "AGGIEX_API_KEY": "${apiKey}",
+        "AGGIEX_BASE_URL": "https://accelerator.aggiex.org"
+      }
+    }
+  }
+}`;
 }
-\`\`\`
 
-## AggieX Accelerator Integration
+const AGENT_CONTEXT = `## AggieX Accelerator Integration
 
 You have access to the AggieX accelerator platform via the \`aggiex\` MCP server.
 
 **Available tools:**
+- \`update_aggiex_mcp\` — Fetch the latest setup instructions and version notes
 - \`get_team_status\` — Team name, current program week, and submission progress
 - \`get_pending_deliverables\` — Deliverables not yet submitted or needing revision
-- \`submit_deliverable(deliverable_id, text_content)\` — Submit a written response for a deliverable
+- \`submit_deliverable(deliverable_id, text_content)\` — Submit a written response
 - \`log_traction(metric_type, value, unit, notes?)\` — Log metrics: users, revenue, LOIs, pilots, retention
 - \`get_traction_history\` — View recent traction log entries
 
@@ -55,7 +63,31 @@ You have access to the AggieX accelerator platform via the \`aggiex\` MCP server
 - Session start: check \`get_team_status\` and \`get_pending_deliverables\`
 - User mentions growth metrics ("200 users", "closed 3 LOIs", "$5k MRR"): offer to \`log_traction\`
 - Work completes on a deliverable: offer to \`submit_deliverable\`
+- Connection errors or config issues: call \`update_aggiex_mcp\` for troubleshooting
 - Always confirm with the user before submitting or logging`;
+
+function buildFullPrompt(apiKey: string, platform: Platform): string {
+  const installLabel = platform === 'windows' ? 'PowerShell' : 'Terminal';
+  return `## AggieX MCP Setup
+
+### 1. Install (run once in ${installLabel})
+
+\`\`\`${platform === 'windows' ? 'powershell' : 'bash'}
+${INSTALL_COMMANDS[platform]}
+\`\`\`
+
+### 2. Configure — add to \`.claude/settings.json\`
+
+\`\`\`json
+${buildMcpConfig(apiKey, platform)}
+\`\`\`
+
+${AGENT_CONTEXT}`;
+}
+
+function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'mac';
+  return /Win/i.test(navigator.userAgent) ? 'windows' : 'mac';
 }
 
 export default function DeveloperPanel() {
@@ -63,8 +95,13 @@ export default function DeveloperPanel() {
   const [isLoading, setIsLoading] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
   const [newKey, setNewKey] = useState<string | null>(null);
+  const [platform, setPlatform] = useState<Platform>('mac');
   const [promptCopied, setPromptCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPlatform(detectPlatform());
+  }, []);
 
   const loadKeys = useCallback(async () => {
     setIsLoading(true);
@@ -98,7 +135,7 @@ export default function DeveloperPanel() {
 
   async function copyPrompt() {
     if (!newKey) return;
-    await navigator.clipboard.writeText(buildFullPrompt(newKey));
+    await navigator.clipboard.writeText(buildFullPrompt(newKey, platform));
     setPromptCopied(true);
     setTimeout(() => setPromptCopied(false), 2000);
   }
@@ -132,15 +169,40 @@ export default function DeveloperPanel() {
           )}
         </div>
       ) : (
-        <div>
-          <p className="mb-4 text-sm text-neutral-400">
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-neutral-400">
             Your setup prompt is ready. Paste it into your project&apos;s{' '}
             <code className="rounded bg-neutral-800 px-1 py-0.5 font-mono text-neutral-300">CLAUDE.md</code>
             {' '}— it includes the install command, MCP config, and agent context with your API key embedded.
           </p>
+
+          {/* Platform toggle */}
+          <div className="flex items-center gap-1 self-start rounded-lg border border-neutral-800 bg-neutral-950 p-1">
+            <button
+              onClick={() => setPlatform('mac')}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                platform === 'mac'
+                  ? 'bg-neutral-700 text-neutral-100'
+                  : 'text-neutral-500 hover:text-neutral-300'
+              }`}
+            >
+              Mac / Linux
+            </button>
+            <button
+              onClick={() => setPlatform('windows')}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                platform === 'windows'
+                  ? 'bg-neutral-700 text-neutral-100'
+                  : 'text-neutral-500 hover:text-neutral-300'
+              }`}
+            >
+              Windows
+            </button>
+          </div>
+
           <button
             onClick={copyPrompt}
-            className="flex items-center gap-2 rounded-md border border-neutral-600 bg-neutral-800 px-5 py-2.5 text-sm font-medium text-neutral-100 transition-colors hover:border-neutral-400 hover:bg-neutral-700"
+            className="flex w-fit items-center gap-2 rounded-md border border-neutral-600 bg-neutral-800 px-5 py-2.5 text-sm font-medium text-neutral-100 transition-colors hover:border-neutral-400 hover:bg-neutral-700"
           >
             {promptCopied ? (
               <>
@@ -154,7 +216,8 @@ export default function DeveloperPanel() {
               </>
             )}
           </button>
-          <p className="mt-3 text-xs text-neutral-600">
+
+          <p className="text-xs text-neutral-600">
             Need to generate another?{' '}
             <button
               onClick={() => setNewKey(null)}


### PR DESCRIPTION
Root cause of connection failures: Claude Code spawns MCP processes directly (no shell), so ~ in args never expands and Homebrew Node isn't on PATH.

Fixes:
- Mac/Linux: use /bin/bash -lc so login profile loads (PATH incl. Node) and ~ expands correctly in the server path
- Windows: use cmd.exe /c with %USERPROFILE% for proper path resolution
- Developer page auto-detects platform via navigator.userAgent and shows a Mac/Linux | Windows toggle; copied prompt uses the selected config

New: update_aggiex_mcp tool
- Fetches mcp-server/AGENT_INSTRUCTIONS.md from GitHub main branch
- Agents call it to get latest config, troubleshooting steps, version notes
- We update AGENT_INSTRUCTIONS.md whenever the server changes; every agent picks it up automatically on next call without a redeploy

New: mcp-server/AGENT_INSTRUCTIONS.md
- Platform-specific install + settings.json configs
- Proactive usage guide
- Troubleshooting section (ENOENT, 401, node not found)