### PR TITLE
fix: remove duplicate shebang causing SyntaxError on Node startup

### DIFF
--- a/mcp-server/dist/index.js
+++ b/mcp-server/dist/index.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-#!/usr/bin/env node
 "use strict";
 var __create = Object.create;
 var __defProp = Object.defineProperty;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {


### PR DESCRIPTION
src/index.ts had #!/usr/bin/env node on line 1. esbuild's --banner:js flag also injects a shebang into the bundle output. The two combined produced a duplicate shebang on line 2 of dist/index.js — Node throws SyntaxError on any shebang that is not on line 1, crashing the MCP server before it ever starts and making all AggieX tools invisible in Claude Code.

Fix: remove the shebang from the source file. The build banner is the sole source of truth for the shebang in the bundle.

Reported by: Vedan (Windows 11, Node v24.15.0)