### PR TITLE
feat: add staff HTTP MCP server with AI meeting notes and program man…

### DIFF
--- a/my-app/app/accelerator/(platform)/components/accelerator-sidebar.tsx
+++ b/my-app/app/accelerator/(platform)/components/accelerator-sidebar.tsx
@@ -181,6 +181,12 @@ const NAV_GROUPS: NavGroup[] = [
         icon: Settings,
         roles: ['aggiex_team'],
       },
+      {
+        label: 'Coding Agent',
+        href: '/accelerator/settings/developer',
+        icon: Code2,
+        roles: ['aggiex_team', 'mce_staff'],
+      },
     ],
   },
 ];

--- a/my-app/app/accelerator/(platform)/settings/developer/components/staff-connect-panel.tsx
+++ b/my-app/app/accelerator/(platform)/settings/developer/components/staff-connect-panel.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Copy, Check, Trash2, Loader2, AlertTriangle } from 'lucide-react';
+
+interface ApiKeyRow {
+  id: string;
+  label: string;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+type KeyStatus = 'idle' | 'verifying' | 'ok' | 'error';
+
+const SESSION_STORAGE_KEY = 'aggiex_staff_raw_key';
+const MCP_URL = 'https://accelerator.aggiex.org/api/mcp';
+
+function buildSettingsJson(apiKey: string): string {
+  return `{
+  "mcpServers": {
+    "aggiex-staff": {
+      "type": "http",
+      "url": "${MCP_URL}",
+      "headers": {
+        "Authorization": "Bearer ${apiKey}"
+      }
+    }
+  }
+}`;
+}
+
+function buildClaudeCommand(apiKey: string): string {
+  return `claude mcp add --transport http aggiex-staff ${MCP_URL} --header "Authorization: Bearer ${apiKey}"`;
+}
+
+const TOOLS_OVERVIEW = `## AggieX Staff MCP — Available Tools
+
+- \`get_program_overview\` — All weeks, teams, and current active week
+- \`get_all_teams_status\` — Submission progress per team for any week
+- \`get_team_detail\` — Full context for a specific team (founders, traction, submissions)
+- \`process_meeting_notes\` — Analyze a meeting notes image (AI vision) → summary, action items, suggested deliverables
+- \`add_deliverable\` — Create a new deliverable for a week and assign to specific teams or all
+- \`update_submission_status\` — Approve, flag, or request revision on a submission
+- \`unlock_week\` — Make a week visible to founders
+- \`create_curriculum_item\` — Add a resource or file to a program week
+
+**Tips:**
+- After connecting, run \`get_program_overview\` to orient the agent on the current program state
+- To process meeting notes: upload the image to any public URL, then call \`process_meeting_notes\` with the URL
+- The agent can chain tools: extract notes → \`add_deliverable\` for any action items found`;
+
+export default function StaffConnectPanel() {
+  const [keys, setKeys] = useState<ApiKeyRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [keyStatus, setKeyStatus] = useState<KeyStatus>('idle');
+  const [keyStatusMessage, setKeyStatusMessage] = useState('');
+  const [copied, setCopied] = useState<Record<string, boolean>>({});
+  const [generateError, setGenerateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (stored) {
+      setActiveKey(stored);
+      setKeyStatus('ok');
+    }
+  }, []);
+
+  const loadKeys = useCallback(async () => {
+    setIsLoading(true);
+    const response = await fetch('/api/accelerator/api-keys');
+    if (response.ok) {
+      const data = await response.json() as ApiKeyRow[];
+      setKeys(data);
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadKeys();
+  }, [loadKeys]);
+
+  async function copyToClipboard(text: string, id: string) {
+    await navigator.clipboard.writeText(text);
+    setCopied((prev) => ({ ...prev, [id]: true }));
+    setTimeout(() => setCopied((prev) => ({ ...prev, [id]: false })), 2000);
+  }
+
+  async function verifyKey(rawKey: string) {
+    setKeyStatus('verifying');
+    const response = await fetch('/api/accelerator/api-keys/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ raw_key: rawKey }),
+    });
+    const data = await response.json() as { valid: boolean; reason?: string };
+    if (data.valid) {
+      setKeyStatus('ok');
+      setKeyStatusMessage('');
+    } else {
+      setKeyStatus('error');
+      setKeyStatusMessage(data.reason ?? 'Verification failed.');
+    }
+  }
+
+  async function generateKey() {
+    setIsGenerating(true);
+    setGenerateError(null);
+    const response = await fetch('/api/accelerator/api-keys', { method: 'POST' });
+    if (!response.ok) {
+      const data = await response.json() as { error?: string };
+      setGenerateError(data.error ?? 'Failed to generate key.');
+      setIsGenerating(false);
+      return;
+    }
+    const data = await response.json() as { raw_key: string };
+    sessionStorage.setItem(SESSION_STORAGE_KEY, data.raw_key);
+    setActiveKey(data.raw_key);
+    await loadKeys();
+    setIsGenerating(false);
+    verifyKey(data.raw_key);
+  }
+
+  async function revokeKey(id: string) {
+    const response = await fetch(`/api/accelerator/api-keys/${id}`, { method: 'DELETE' });
+    if (response.ok) {
+      setKeys((prev) => prev.filter((key) => key.id !== id));
+      sessionStorage.removeItem(SESSION_STORAGE_KEY);
+      setActiveKey(null);
+      setKeyStatus('idle');
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+
+      {!activeKey ? (
+        <div>
+          <p className="mb-4 text-sm text-neutral-400">
+            Generate an API key to connect your coding agent to the AggieX staff tools.
+          </p>
+          <button
+            onClick={generateKey}
+            disabled={isGenerating}
+            className="rounded-md border border-neutral-700 bg-neutral-900 px-4 py-2 text-sm text-neutral-200 transition-colors hover:border-neutral-500 hover:text-white disabled:opacity-50"
+          >
+            {isGenerating ? 'Generating…' : 'Generate API key'}
+          </button>
+          {generateError && (
+            <p className="mt-3 rounded-md bg-red-500/10 px-3 py-2 text-xs text-red-400">
+              {generateError}
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {keyStatus === 'verifying' && (
+            <div className="flex items-center gap-2 text-xs text-neutral-500">
+              <Loader2 size={12} className="animate-spin" />
+              Verifying key…
+            </div>
+          )}
+          {keyStatus === 'ok' && (
+            <div className="flex items-center gap-1.5 text-xs text-emerald-500">
+              <Check size={12} />
+              Key verified — ready to connect
+            </div>
+          )}
+          {keyStatus === 'error' && (
+            <div className="rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2.5">
+              <div className="flex items-center gap-1.5 text-xs font-medium text-red-400">
+                <AlertTriangle size={12} />
+                Verification failed
+              </div>
+              <p className="mt-1 text-xs text-red-400/70">{keyStatusMessage}</p>
+            </div>
+          )}
+
+          {/* Claude Code CLI */}
+          <div>
+            <p className="mb-2 text-xs font-medium text-neutral-300">Claude Code — run in terminal</p>
+            <div className="relative rounded-lg border border-neutral-800 bg-neutral-950">
+              <pre className="overflow-x-auto px-4 py-3 pr-12 font-mono text-xs text-neutral-300">
+                {buildClaudeCommand(activeKey)}
+              </pre>
+              <button
+                onClick={() => copyToClipboard(buildClaudeCommand(activeKey), 'cli')}
+                className="absolute right-2 top-2 flex items-center gap-1 rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs text-neutral-400 transition-colors hover:border-neutral-500 hover:text-white"
+              >
+                {copied['cli'] ? <Check size={11} className="text-emerald-400" /> : <Copy size={11} />}
+              </button>
+            </div>
+          </div>
+
+          {/* settings.json for Cursor / other editors */}
+          <div>
+            <p className="mb-2 text-xs font-medium text-neutral-300">
+              Cursor / other editors — add to <code className="rounded bg-neutral-800 px-1 py-0.5 font-mono text-neutral-400">.cursor/mcp.json</code> or equivalent
+            </p>
+            <div className="relative rounded-lg border border-neutral-800 bg-neutral-950">
+              <pre className="overflow-x-auto px-4 py-4 pr-12 font-mono text-xs text-neutral-300">
+                {buildSettingsJson(activeKey)}
+              </pre>
+              <button
+                onClick={() => copyToClipboard(buildSettingsJson(activeKey), 'json')}
+                className="absolute right-2 top-2 flex items-center gap-1 rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs text-neutral-400 transition-colors hover:border-neutral-500 hover:text-white"
+              >
+                {copied['json'] ? <Check size={11} className="text-emerald-400" /> : <Copy size={11} />}
+              </button>
+            </div>
+          </div>
+
+          {/* Tools overview */}
+          <div>
+            <p className="mb-2 text-xs font-medium text-neutral-300">
+              CLAUDE.md context — paste into your project to guide the agent
+            </p>
+            <div className="relative rounded-lg border border-neutral-800 bg-neutral-950">
+              <pre className="overflow-x-auto whitespace-pre-wrap px-4 py-4 pr-12 font-mono text-xs text-neutral-300">
+                {TOOLS_OVERVIEW}
+              </pre>
+              <button
+                onClick={() => copyToClipboard(TOOLS_OVERVIEW, 'context')}
+                className="absolute right-2 top-2 flex items-center gap-1 rounded-md border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs text-neutral-400 transition-colors hover:border-neutral-500 hover:text-white"
+              >
+                {copied['context'] ? <Check size={11} className="text-emerald-400" /> : <Copy size={11} />}
+              </button>
+            </div>
+          </div>
+
+          <p className="text-xs text-neutral-600">
+            <button
+              onClick={() => {
+                sessionStorage.removeItem(SESSION_STORAGE_KEY);
+                setActiveKey(null);
+                setKeyStatus('idle');
+              }}
+              className="text-neutral-500 underline underline-offset-2 hover:text-neutral-300"
+            >
+              Generate a new key
+            </button>
+          </p>
+        </div>
+      )}
+
+      {!isLoading && keys.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs uppercase tracking-widest text-neutral-600">Active keys</p>
+          <div className="flex flex-col gap-2">
+            {keys.map((key) => (
+              <div
+                key={key.id}
+                className="flex items-center justify-between rounded-lg border border-neutral-800 px-4 py-3"
+              >
+                <div>
+                  <p className="text-sm text-neutral-300">{key.label}</p>
+                  <p className="mt-0.5 text-xs text-neutral-600">
+                    Created {new Date(key.created_at).toLocaleDateString()}
+                    {key.last_used_at && (
+                      <> · Last used {new Date(key.last_used_at).toLocaleDateString()}</>
+                    )}
+                  </p>
+                </div>
+                <button
+                  onClick={() => revokeKey(key.id)}
+                  title="Revoke key"
+                  className="ml-4 flex h-7 w-7 items-center justify-center rounded-md text-neutral-600 transition-colors hover:bg-red-500/10 hover:text-red-400"
+                >
+                  <Trash2 size={13} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+    </div>
+  );
+}

--- a/my-app/app/accelerator/(platform)/settings/developer/page.tsx
+++ b/my-app/app/accelerator/(platform)/settings/developer/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import StaffConnectPanel from './components/staff-connect-panel';
+
+export default async function StaffDeveloperPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/auth/login');
+
+  const { data: profile } = await supabase
+    .from('accel_profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (!['aggiex_team', 'mce_staff'].includes(profile?.role ?? '')) {
+    redirect('/accelerator/dashboard');
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-8">
+      <div className="mb-8">
+        <p className="text-xs uppercase tracking-widest text-neutral-500">Settings</p>
+        <h1 className="mt-1 text-xl font-semibold text-neutral-100">Coding Agent</h1>
+        <p className="mt-0.5 text-sm text-neutral-500">
+          Connect Claude Code, Cursor, or any MCP-compatible agent to the AggieX staff tools.
+        </p>
+      </div>
+      <StaffConnectPanel />
+    </div>
+  );
+}

--- a/my-app/app/api/accelerator/api-keys/route.ts
+++ b/my-app/app/api/accelerator/api-keys/route.ts
@@ -3,8 +3,10 @@ import { createHash, randomBytes } from 'crypto';
 import { requireAccelRole } from '@/lib/accel-auth';
 import { createClient } from '@/lib/supabase/server';
 
+const ALLOWED_ROLES = ['founder', 'aggiex_team', 'mce_staff'] as const;
+
 export async function GET() {
-  const { profile, error } = await requireAccelRole(['founder']);
+  const { profile, error } = await requireAccelRole([...ALLOWED_ROLES]);
   if (error) return error;
 
   const supabase = await createClient();
@@ -19,10 +21,11 @@ export async function GET() {
 }
 
 export async function POST() {
-  const { profile, error } = await requireAccelRole(['founder']);
+  const { profile, error } = await requireAccelRole([...ALLOWED_ROLES]);
   if (error) return error;
 
-  if (!profile.team_id) {
+  // Founders must be on a team; staff generate keys for themselves directly
+  if (profile.role === 'founder' && !profile.team_id) {
     return NextResponse.json({ error: 'No team assigned' }, { status: 400 });
   }
 

--- a/my-app/app/api/accelerator/api-keys/verify/route.ts
+++ b/my-app/app/api/accelerator/api-keys/verify/route.ts
@@ -7,7 +7,7 @@ import { createAdminClient } from '@/lib/supabase/accel-admin';
 // the key is reachable via the admin client (catches missing migration,
 // missing SUPABASE_SERVICE_ROLE_KEY, and other infrastructure issues).
 export async function POST(request: NextRequest) {
-  const { error } = await requireAccelRole(['founder']);
+  const { error } = await requireAccelRole(['founder', 'aggiex_team', 'mce_staff']);
   if (error) return error;
 
   let body: unknown;

--- a/my-app/app/api/mcp/route.ts
+++ b/my-app/app/api/mcp/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAccelAuth } from '@/lib/accel-auth';
+import { STAFF_TOOLS, handleToolCall } from './tools';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const SERVER_INFO = {
+  name: 'aggiex-staff',
+  version: '1.0.0',
+  instructions:
+    'AggieX staff tools for program management. ' +
+    'Use process_meeting_notes to analyze a photo of meeting notes and extract action items. ' +
+    'Use add_deliverable to create deliverables for teams. ' +
+    'All reads return live data from the AggieX platform.',
+};
+
+interface McpMessage {
+  jsonrpc: '2.0';
+  id?: string | number | null;
+  method: string;
+  params?: unknown;
+}
+
+function ok(id: string | number | null | undefined, result: unknown) {
+  return NextResponse.json({ jsonrpc: '2.0', id: id ?? null, result });
+}
+
+function mcpError(id: string | number | null | undefined, code: number, message: string) {
+  return NextResponse.json({ jsonrpc: '2.0', id: id ?? null, error: { code, message } });
+}
+
+export async function POST(request: NextRequest) {
+  const { profile, error: authError } = await requireAccelAuth(request, ['aggiex_team', 'mce_staff']);
+  if (authError) return authError;
+
+  let body: McpMessage;
+  try {
+    body = await request.json() as McpMessage;
+  } catch {
+    return mcpError(null, -32700, 'Parse error');
+  }
+
+  const { method, params, id } = body;
+
+  // Notifications (no id) expect no JSON response — 202 Accepted
+  if (id === undefined && method.startsWith('notifications/')) {
+    return new NextResponse(null, { status: 202 });
+  }
+
+  switch (method) {
+    case 'initialize':
+      return ok(id, {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      });
+
+    case 'ping':
+      return ok(id, {});
+
+    case 'tools/list':
+      return ok(id, { tools: STAFF_TOOLS });
+
+    case 'tools/call': {
+      const { name, arguments: args = {} } = params as {
+        name: string;
+        arguments?: Record<string, unknown>;
+      };
+      try {
+        const content = await handleToolCall(name, args, profile);
+        return ok(id, { content });
+      } catch (err) {
+        return ok(id, {
+          content: [{ type: 'text', text: `Error: ${(err as Error).message}` }],
+          isError: true,
+        });
+      }
+    }
+
+    default:
+      return mcpError(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+// GET is required by the Streamable HTTP spec for SSE streaming sessions.
+// We don't support persistent streaming — return 405 so clients fall back to polling.
+export async function GET() {
+  return new NextResponse('Streaming sessions not supported — use POST for tool calls.', {
+    status: 405,
+  });
+}

--- a/my-app/app/api/mcp/tools.ts
+++ b/my-app/app/api/mcp/tools.ts
@@ -1,0 +1,359 @@
+import { createGroq } from '@ai-sdk/groq';
+import { generateText } from 'ai';
+import { createAdminClient } from '@/lib/supabase/accel-admin';
+import type { AccelProfile } from '@/lib/accel-types';
+
+const groq = createGroq({ apiKey: process.env.GROQ_API_KEY });
+
+type ToolContent = Array<{ type: 'text'; text: string }>;
+
+function text(value: unknown): ToolContent {
+  return [{ type: 'text', text: typeof value === 'string' ? value : JSON.stringify(value, null, 2) }];
+}
+
+// ─── Tool definitions ────────────────────────────────────────────────────────
+
+export const STAFF_TOOLS = [
+  {
+    name: 'get_program_overview',
+    description:
+      'Get the full AggieX program context: all weeks with themes, lock status, team list, and current active week.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_all_teams_status',
+    description:
+      'Get submission progress for every team in the current (or a specified) week. ' +
+      'Returns counts of submitted, pending, and flagged deliverables per team.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        week_number: {
+          type: 'number',
+          description: 'Week number to query (defaults to the current unlocked week)',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_team_detail',
+    description: 'Get full context for a specific team: founders, submission history, and recent traction.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        team_name: { type: 'string', description: 'Team name (partial match supported)' },
+      },
+      required: ['team_name'],
+    },
+  },
+  {
+    name: 'process_meeting_notes',
+    description:
+      'Analyze a photo or screenshot of meeting notes using AI vision. ' +
+      'Returns a structured summary with key decisions, action items per team, ' +
+      'and suggested deliverables to add. Provide a publicly accessible image URL.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        image_url: {
+          type: 'string',
+          description: 'Publicly accessible URL of the meeting notes image (JPEG, PNG, WEBP)',
+        },
+        context: {
+          type: 'string',
+          description: 'Optional: brief context about the meeting (e.g. "Week 3 check-in", "Demo Day prep")',
+        },
+      },
+      required: ['image_url'],
+    },
+  },
+  {
+    name: 'add_deliverable',
+    description:
+      'Create a new deliverable for a program week. ' +
+      'Leave assigned_team_ids null to assign to all teams, or pass specific team UUIDs.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        week_id: { type: 'string', description: 'UUID of the program week' },
+        title: { type: 'string', description: 'Deliverable title (max 300 chars)' },
+        description: { type: 'string', description: 'What founders need to submit' },
+        expected_format: {
+          type: 'string',
+          enum: ['text', 'file', 'link', 'any'],
+          description: 'Expected submission format',
+        },
+        is_required: { type: 'boolean', description: 'Whether this is required (default true)' },
+        assigned_team_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Specific team UUIDs to assign, or omit/null for all teams',
+          nullable: true,
+        },
+      },
+      required: ['week_id', 'title', 'expected_format'],
+    },
+  },
+  {
+    name: 'update_submission_status',
+    description:
+      "Update a team's submission status. Use this to approve, flag, or request revision on a submitted deliverable.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        submission_id: { type: 'string', description: 'UUID of the submission' },
+        status: {
+          type: 'string',
+          enum: ['approved', 'needs_revision', 'flagged', 'under_review'],
+          description: 'New status',
+        },
+        comments: { type: 'string', description: 'Optional feedback for the team' },
+      },
+      required: ['submission_id', 'status'],
+    },
+  },
+  {
+    name: 'unlock_week',
+    description: 'Unlock a program week so founders can see its deliverables and curriculum.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        week_id: { type: 'string', description: 'UUID of the week to unlock' },
+      },
+      required: ['week_id'],
+    },
+  },
+  {
+    name: 'create_curriculum_item',
+    description: 'Add a curriculum file or resource to a program week.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        week_id: { type: 'string', description: 'UUID of the week (or omit for program-wide)' },
+        title: { type: 'string', description: 'Resource title' },
+        description: { type: 'string', description: 'Brief description of the resource' },
+        file_url: { type: 'string', description: 'URL of the file or external link' },
+        file_type: {
+          type: 'string',
+          enum: ['pdf', 'docx', 'video_link', 'external_link', 'other'],
+          description: 'Type of the resource',
+        },
+        access_level: {
+          type: 'string',
+          enum: ['all', 'founders_only', 'aggiex_internal'],
+          description: 'Who can see this resource (default: founders_only)',
+        },
+      },
+      required: ['title', 'file_url', 'file_type'],
+    },
+  },
+];
+
+// ─── Tool implementations ────────────────────────────────────────────────────
+
+export async function handleToolCall(
+  name: string,
+  args: Record<string, unknown>,
+  profile: AccelProfile
+): Promise<ToolContent> {
+  const admin = createAdminClient();
+
+  if (name === 'get_program_overview') {
+    const [weeksResult, teamsResult] = await Promise.all([
+      admin
+        .from('accel_weeks')
+        .select('id, week_number, theme, is_unlocked, start_date, end_date')
+        .order('week_number'),
+      admin.from('accel_teams').select('id, name, is_active').eq('is_active', true),
+    ]);
+    return text({
+      weeks: weeksResult.data ?? [],
+      teams: teamsResult.data ?? [],
+      current_week:
+        (weeksResult.data ?? []).filter((w) => w.is_unlocked).at(-1) ?? null,
+    });
+  }
+
+  if (name === 'get_all_teams_status') {
+    const weekNumber = args.week_number as number | undefined;
+
+    let weekQuery = admin.from('accel_weeks').select('id, week_number, theme').eq('is_unlocked', true);
+    if (weekNumber) weekQuery = weekQuery.eq('week_number', weekNumber);
+    const { data: weeks } = await weekQuery.order('week_number', { ascending: false }).limit(1);
+    const week = weeks?.[0];
+    if (!week) return text('No unlocked weeks found.');
+
+    const { data: deliverables } = await admin
+      .from('accel_deliverables')
+      .select('id, title, is_required')
+      .eq('week_id', week.id);
+
+    const { data: submissions } = await admin
+      .from('accel_submissions')
+      .select('team_id, deliverable_id, status')
+      .in('deliverable_id', (deliverables ?? []).map((d) => d.id));
+
+    const { data: teams } = await admin
+      .from('accel_teams')
+      .select('id, name')
+      .eq('is_active', true);
+
+    const statusByTeam = (teams ?? []).map((team) => {
+      const teamSubs = (submissions ?? []).filter((s) => s.team_id === team.id);
+      const submitted = teamSubs.filter((s) =>
+        ['submitted', 'under_review', 'approved'].includes(s.status)
+      ).length;
+      const flagged = teamSubs.filter((s) => s.status === 'flagged').length;
+      const total = (deliverables ?? []).length;
+      return { team: team.name, submitted, flagged, total, pending: total - submitted };
+    });
+
+    return text({ week: `Week ${week.week_number} — ${week.theme}`, teams: statusByTeam });
+  }
+
+  if (name === 'get_team_detail') {
+    const teamName = args.team_name as string;
+    const { data: teams } = await admin
+      .from('accel_teams')
+      .select('id, name, venture_stage, industry_vertical, website')
+      .ilike('name', `%${teamName}%`)
+      .limit(1);
+
+    const team = teams?.[0];
+    if (!team) return text(`No team found matching "${teamName}".`);
+
+    const [profilesResult, tractionResult, submissionsResult] = await Promise.all([
+      admin
+        .from('accel_profiles')
+        .select('full_name, email, role')
+        .eq('team_id', team.id),
+      admin
+        .from('accel_traction_entries')
+        .select('metric_type, value, unit, entry_date, notes')
+        .eq('team_id', team.id)
+        .order('entry_date', { ascending: false })
+        .limit(10),
+      admin
+        .from('accel_submissions')
+        .select('deliverable_id, status, version, submitted_at')
+        .eq('team_id', team.id)
+        .order('submitted_at', { ascending: false })
+        .limit(20),
+    ]);
+
+    return text({
+      team,
+      members: profilesResult.data ?? [],
+      recent_traction: tractionResult.data ?? [],
+      recent_submissions: submissionsResult.data ?? [],
+    });
+  }
+
+  if (name === 'process_meeting_notes') {
+    const imageUrl = args.image_url as string;
+    const context = (args.context as string | undefined) ?? '';
+
+    const { text: extracted } = await generateText({
+      model: groq('llama-3.2-90b-vision-preview'),
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'image', image: new URL(imageUrl) },
+            {
+              type: 'text',
+              text: [
+                context ? `Meeting context: ${context}` : '',
+                'You are analyzing meeting notes for the AggieX startup accelerator.',
+                'Extract and structure the following from the image:',
+                '1. Meeting summary (2-3 sentences)',
+                '2. Key decisions made',
+                '3. Action items — list each with: owner (team name or person), action, deadline if visible',
+                '4. Suggested deliverables to add to the platform (title, description, format: text/file/link)',
+                '5. Any traction metrics mentioned (metric, value, team)',
+                'Be concise and precise. If something is illegible, note it.',
+              ]
+                .filter(Boolean)
+                .join('\n'),
+            },
+          ],
+        },
+      ],
+    });
+
+    return text(extracted);
+  }
+
+  if (name === 'add_deliverable') {
+    const { data, error } = await admin
+      .from('accel_deliverables')
+      .insert({
+        week_id: args.week_id as string,
+        title: args.title as string,
+        description: (args.description as string) ?? null,
+        expected_format: (args.expected_format as string) ?? 'any',
+        is_required: (args.is_required as boolean) ?? true,
+        sort_order: 0,
+        assigned_team_ids: (args.assigned_team_ids as string[] | null) ?? null,
+      })
+      .select('id, title, week_id')
+      .single();
+
+    if (error) throw new Error(error.message);
+    return text(`Deliverable created: "${data.title}" (${data.id})`);
+  }
+
+  if (name === 'update_submission_status') {
+    const updates: Record<string, unknown> = {
+      status: args.status,
+      updated_at: new Date().toISOString(),
+    };
+    if (args.comments) updates.review_comments = args.comments;
+
+    const { error } = await admin
+      .from('accel_submissions')
+      .update(updates)
+      .eq('id', args.submission_id as string);
+
+    if (error) throw new Error(error.message);
+    return text(`Submission ${args.submission_id} updated to "${args.status}".`);
+  }
+
+  if (name === 'unlock_week') {
+    const { error } = await admin
+      .from('accel_weeks')
+      .update({
+        is_unlocked: true,
+        unlocked_at: new Date().toISOString(),
+        unlocked_by: profile.id,
+      })
+      .eq('id', args.week_id as string);
+
+    if (error) throw new Error(error.message);
+    return text(`Week ${args.week_id} unlocked.`);
+  }
+
+  if (name === 'create_curriculum_item') {
+    const { data, error } = await admin
+      .from('accel_curriculum_files')
+      .insert({
+        week_id: (args.week_id as string) ?? null,
+        program_id: (await admin.from('accel_programs').select('id').eq('is_active', true).single()).data?.id,
+        uploader_id: profile.id,
+        title: args.title as string,
+        description: (args.description as string) ?? null,
+        file_url: args.file_url as string,
+        file_type: args.file_type as string,
+        access_level: (args.access_level as string) ?? 'founders_only',
+        is_active: true,
+      })
+      .select('id, title')
+      .single();
+
+    if (error) throw new Error(error.message);
+    return text(`Curriculum item created: "${data.title}" (${data.id})`);
+  }
+
+  return text(`Unknown tool: ${name}`);
+}

--- a/supabase/migrations/20260603000001_api_keys_nullable_team.sql
+++ b/supabase/migrations/20260603000001_api_keys_nullable_team.sql
@@ -1,0 +1,5 @@
+-- Allow accel_api_keys.team_id to be NULL so aggiex_team / mce_staff
+-- members can generate API keys for the staff MCP server without being
+-- assigned to a startup team.
+ALTER TABLE accel_api_keys
+  ALTER COLUMN team_id DROP NOT NULL;


### PR DESCRIPTION
…agement tools

- New /api/mcp endpoint: custom Streamable HTTP JSON-RPC handler for staff roles
- 8 tools: get_program_overview, get_all_teams_status, get_team_detail, process_meeting_notes (Groq vision), add_deliverable, update_submission_status, unlock_week, create_curriculum_item
- Staff connect page at /accelerator/settings/developer with sessionStorage key persistence, verify-on-generate, and one-click copy for Claude Code CLI + Cursor JSON
- Allow aggiex_team/mce_staff to generate API keys (nullable team_id migration)
- Add Coding Agent sidebar link for staff in Admin section
- Fix verify endpoint to accept all staff roles