### PR TITLE
fix: use admin client for DB queries when authenticating via API key

### DIFF
--- a/my-app/app/api/accelerator/deliverables/route.ts
+++ b/my-app/app/api/accelerator/deliverables/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireAccelRole, requireAccelAuth } from '@/lib/accel-auth';
 import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/accel-admin';
 
 const CreateDeliverableSchema = z.object({
   week_id: z.string().uuid(),
@@ -21,9 +22,9 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const weekId = searchParams.get('week_id');
 
-  const supabase = await createClient();
+  const admin = createAdminClient();
 
-  let query = supabase
+  let query = admin
     .from('accel_deliverables')
     .select(`
       id, week_id, title, description, is_required,

--- a/my-app/app/api/accelerator/me/route.ts
+++ b/my-app/app/api/accelerator/me/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAccelAuth } from '@/lib/accel-auth';
-import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/accel-admin';
 
 export async function GET(request: NextRequest) {
@@ -8,13 +7,12 @@ export async function GET(request: NextRequest) {
   if (error) return error;
 
   const admin = createAdminClient();
-  const supabase = await createClient();
 
   const [teamResult, weekResult] = await Promise.all([
     profile.team_id
       ? admin.from('accel_teams').select('id, name, venture_stage').eq('id', profile.team_id).single()
       : Promise.resolve({ data: null }),
-    supabase
+    admin
       .from('accel_weeks')
       .select('week_number, theme')
       .eq('is_unlocked', true)

--- a/my-app/app/api/accelerator/submissions/route.ts
+++ b/my-app/app/api/accelerator/submissions/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireAccelRole, requireAccelAuth } from '@/lib/accel-auth';
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/accel-admin';
 
 const UpsertSubmissionSchema = z.object({
   deliverable_id: z.string().uuid(),
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'team_id required' }, { status: 400 });
   }
 
-  const supabase = await createClient();
+  const supabase = createAdminClient();
   const { data, error: dbError } = await supabase
     .from('accel_submissions')
     .select('id, deliverable_id, status, version, submitted_at')
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  const supabase = await createClient();
+  const supabase = createAdminClient();
 
   // Check for an existing latest submission to version correctly
   const { data: existing } = await supabase

--- a/my-app/app/api/accelerator/traction/route.ts
+++ b/my-app/app/api/accelerator/traction/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { requireAccelRole, requireAccelAuth } from '@/lib/accel-auth';
-import { createClient } from '@/lib/supabase/server';
+import { requireAccelAuth } from '@/lib/accel-auth';
+import { createAdminClient } from '@/lib/supabase/accel-admin';
 
 const CreateTractionSchema = z.object({
   team_id: z.string().uuid(),
@@ -17,7 +17,7 @@ const CreateTractionSchema = z.object({
 });
 
 export async function GET(request: NextRequest) {
-  const { error } = await requireAccelRole([
+  const { error } = await requireAccelAuth(request, [
     'founder', 'aggiex_team', 'mce_staff', 'mentor',
   ]);
   if (error) return error;
@@ -26,9 +26,9 @@ export async function GET(request: NextRequest) {
   const teamId = searchParams.get('team_id');
   const metricType = searchParams.get('metric_type');
 
-  const supabase = await createClient();
+  const admin = createAdminClient();
 
-  let query = supabase
+  let query = admin
     .from('accel_traction_entries')
     .select('*, accel_weeks(week_number)')
     .order('entry_date', { ascending: false })
@@ -71,9 +71,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  const supabase = await createClient();
+  const admin = createAdminClient();
 
-  const { data, error: dbError } = await supabase
+  const { data, error: dbError } = await admin
     .from('accel_traction_entries')
     .insert({ ...parsed.data, logged_by: profile.id })
     .select()


### PR DESCRIPTION
Routes that support API key auth were calling createClient() (session-based) after requireAccelAuth() succeeded. Without a session cookie, that creates an anonymous Supabase client — RLS blocks all queries, so founders got empty data or 401 on every MCP tool call.

Fix: switch me, deliverables, submissions, and traction to createAdminClient() for their DB queries. Data access is still scoped to the profile returned by requireAccelAuth (founders can only read/write their own team's data).

Also fixes traction GET which was using requireAccelRole (session-only) instead of requireAccelAuth, causing a hard 401 for any API key caller.