### PR TITLE
fix: extract advisor shared types to client-safe module

### DIFF
--- a/my-app/app/accelerator/(platform)/ai-advisor/components/ai-advisor-chat.tsx
+++ b/my-app/app/accelerator/(platform)/ai-advisor/components/ai-advisor-chat.tsx
@@ -6,8 +6,8 @@ import Image from 'next/image';
 import { Send, Loader2, RotateCcw, X, AlertCircle, Mic, MicOff, CheckCircle2, Sparkles } from 'lucide-react';
 import type { AccelRole } from '@/lib/accel-types';
 import type { ExtractionResult } from '@/app/api/accelerator/ai-advisor/extract/route';
-import type { PendingAction } from '@/lib/ai/advisor-tools';
-import { PENDING_ACTION_PART_TYPE } from '@/lib/ai/advisor-tools';
+import type { PendingAction } from '@/lib/ai/advisor-types';
+import { PENDING_ACTION_PART_TYPE } from '@/lib/ai/advisor-types';
 
 type ExtractionWithTeam = ExtractionResult & { team_id: string };
 

--- a/my-app/lib/ai/advisor-tools.ts
+++ b/my-app/lib/ai/advisor-tools.ts
@@ -9,35 +9,12 @@ import { handleFounderToolCall } from '@/app/api/mcp/founder/tools';
 import { handleToolCall } from '@/app/api/mcp/tools';
 import { getRedis } from '@/lib/redis';
 import type { AccelProfile } from '@/lib/accel-types';
+import type { PendingSubmit, PendingTraction } from '@/lib/ai/advisor-types';
 
-// The shape written to the UI message stream when a write tool is called.
-// The client ActionCard reads this to show a confirm card.
-export type PendingSubmit = {
-  status: 'pending_confirm';
-  action: 'submit_deliverable';
-  deliverable_id: string;
-  deliverable_title: string;
-  text_content: string;
-  text_preview: string;
-  team_id: string;
-  summary: string;
-};
-
-export type PendingTraction = {
-  status: 'pending_confirm';
-  action: 'log_traction';
-  metric_type: string;
-  value: number;
-  unit: string;
-  notes: string;
-  team_id: string;
-  summary: string;
-};
-
-export type PendingAction = PendingSubmit | PendingTraction;
-
-// The data-part type name written to the UI message stream.
-export const PENDING_ACTION_PART_TYPE = 'data-pending-action' as const;
+// Re-export shared types and constants so server-side callers only need one import.
+export type { PendingSubmit, PendingTraction } from '@/lib/ai/advisor-types';
+export type { PendingAction } from '@/lib/ai/advisor-types';
+export { PENDING_ACTION_PART_TYPE } from '@/lib/ai/advisor-types';
 
 // Tools that should trigger a data-pending-action chunk when they fire.
 export const ADVISOR_WRITE_TOOL_NAMES = new Set(['submit_deliverable', 'log_traction']);

--- a/my-app/lib/ai/advisor-types.ts
+++ b/my-app/lib/ai/advisor-types.ts
@@ -1,0 +1,28 @@
+// Shared types and constants for the AI Advisor agent.
+// No server-only imports — safe to use in both client and server code.
+
+export const PENDING_ACTION_PART_TYPE = 'data-pending-action' as const;
+
+export type PendingSubmit = {
+  status: 'pending_confirm';
+  action: 'submit_deliverable';
+  deliverable_id: string;
+  deliverable_title: string;
+  text_content: string;
+  text_preview: string;
+  team_id: string;
+  summary: string;
+};
+
+export type PendingTraction = {
+  status: 'pending_confirm';
+  action: 'log_traction';
+  metric_type: string;
+  value: number;
+  unit: string;
+  notes: string;
+  team_id: string;
+  summary: string;
+};
+
+export type PendingAction = PendingSubmit | PendingTraction;


### PR DESCRIPTION
Importing PENDING_ACTION_PART_TYPE from advisor-tools.ts in a 'use client' component pulled server-only modules into the client bundle, causing a circular dependency TDZ error at runtime.

Move the constant and PendingAction types to advisor-types.ts (no server imports). Client component now imports from there; advisor-tools.ts re-exports for server-side callers.