### PR TITLE
fix: use onChunk instead of textStream for multi-step tool streaming

### DIFF
--- a/my-app/app/api/accelerator/ai-advisor/route.ts
+++ b/my-app/app/api/accelerator/ai-advisor/route.ts
@@ -144,11 +144,15 @@ export async function POST(request: NextRequest) {
           maxTokens: 1024,
           temperature: 0.3,
           ...(advisorTools ? { tools: advisorTools, maxSteps: 5 } : {}),
+          onChunk({ chunk }) {
+            if (chunk.type === 'text-delta') {
+              controller.enqueue(encoder.encode(chunk.textDelta));
+            }
+          },
         });
 
-        for await (const chunk of result.textStream) {
-          controller.enqueue(encoder.encode(chunk));
-        }
+        // Await full completion (including all tool-call steps).
+        await result.text;
       };
 
       try {


### PR DESCRIPTION
textStream can miss text from later steps when maxSteps > 1 and the first step is a pure tool call. onChunk fires for every text-delta across all steps; await result.text waits for full completion.