### PR TITLE
fix: add specificationVersion v3 to wrapLanguageModel middleware

### DIFF
--- a/my-app/app/api/accelerator/ai-advisor/route.ts
+++ b/my-app/app/api/accelerator/ai-advisor/route.ts
@@ -63,6 +63,7 @@ function buildModelWithFallback() {
   return wrapLanguageModel({
     model: groqProvider('llama-3.3-70b-versatile'),
     middleware: {
+      specificationVersion: 'v3',
       wrapStream: async ({ doStream, params }) => {
         try {
           return await doStream();


### PR DESCRIPTION
AI SDK v6 uses LanguageModelV3Middleware which requires specificationVersion: 'v3' on the middleware object. Without it the middleware validation fails at runtime causing a 500 Internal Server Error before any stream is initiated.