### PR TITLE
fix: replace maxSteps with stopWhen: stepCountIs(5) for AI SDK v6

### DIFF
--- a/my-app/app/api/accelerator/ai-advisor/route.ts
+++ b/my-app/app/api/accelerator/ai-advisor/route.ts
@@ -1,6 +1,6 @@
 import { createGroq } from '@ai-sdk/groq';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
-import { streamText, convertToModelMessages, wrapLanguageModel } from 'ai';
+import { streamText, convertToModelMessages, wrapLanguageModel, stepCountIs } from 'ai';
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
@@ -160,7 +160,9 @@ export async function POST(request: NextRequest) {
     messages: modelMessages,
     maxTokens: 1024,
     temperature: 0.3,
-    ...(advisorTools ? { tools: advisorTools, maxSteps: 5 } : {}),
+    // AI SDK v6: maxSteps renamed to stopWhen; default is stepCountIs(1) which
+    // stops after the first tool call and never generates a text response.
+    ...(advisorTools ? { tools: advisorTools, stopWhen: stepCountIs(5) } : {}),
   }).toUIMessageStreamResponse({
     onError: (error) => {
       console.error('[ai-advisor] Stream error:', error);


### PR DESCRIPTION
In AI SDK v6, maxSteps was replaced by stopWhen. The default is stepCountIs(1) which stops the loop after a single LLM call — so the model calls a tool in step 1, gets the result, and then the stream ends without ever generating a text response. The user sees an empty chat bubble.

Passing maxSteps: 5 was silently ignored (unknown option), leaving stopWhen at its default of stepCountIs(1).

Fix: import and use stopWhen: stepCountIs(5) so the model continues to step 2 (generating text from tool results) as intended.