### PR TITLE
v0.1.2 feat: curriculum file uploads + AI embedding pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## [0.1.2] - 2026-06-09
+
+### Added
+- Curriculum file upload: staff can now upload PDFs and DOCXs directly from the curriculum form instead of only entering URLs. Files are stored in Supabase Storage.
+- Automatic AI embedding of uploaded curriculum files: when a PDF or DOCX is uploaded as a curriculum resource, its full text content is extracted and indexed into the RAG pipeline automatically (via `next/server after()`). The AI Advisor can now answer questions about the actual content of uploaded slides and documents, not just their titles.
+- `lib/ai/extract-file-text.ts`: shared text extraction utility (pdf-parse, mammoth) used by both the embedding pipeline and the context-docs upload route.
+- `deleteCurriculumFileEmbeddings()` and `embedCurriculumFile()` exports from the embedding pipeline for single-record background indexing.
+- Curriculum embedding cleanup: hiding (`is_active=false`) or deleting a curriculum file immediately removes its embedding rows from the vector store in the background.
+
+### Changed
+- Curriculum bucket added to the upload API (`/api/upload/[bucket]`) with PDF/DOCX MIME type restriction.
+- `embedCurriculumFiles()` in the embedding pipeline now fetches and parses file content for pdf/docx resources, embedding the full document text rather than just title + description. Change detection uses a URL-based hash so unchanged files are skipped without re-fetching.
+- `context-docs/route.ts` now uses the shared `extractTextFromBuffer` utility instead of inline pdf-parse/mammoth calls.
+- Gemini 2.0 Flash replaced with Gemini 2.5 Flash (model deprecation).
+
+### Fixed
+- Security: auth-gated search routes (`/api/search/*`) that were previously unauthenticated.
+- Security: added AI rate limiting to the advisor endpoint.
+- Security: removed debug/test endpoints (`/api/debug`, `/api/test/auth`, `/admin/auth-monitoring`).
+- Security: implemented CSO audit findings — hardened session handling, removed insecure patterns.
+- Security: removed `.gstack/` browse logs from the repository; added to `.gitignore`.
+- MCP: destructured `keyId` from `requireAccelAuth` response to fix auth in MCP route handlers.
+
+## [0.1.1] - 2026-06-08
+
+Initial accelerator platform release.

--- a/my-app/app/accelerator/(platform)/curriculum/components/upload-curriculum-form.tsx
+++ b/my-app/app/accelerator/(platform)/curriculum/components/upload-curriculum-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -24,7 +24,7 @@ const UploadSchema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
   description: z.string().max(1000).optional(),
   file_type: z.enum(['pdf', 'docx', 'video_link', 'external_link', 'other']),
-  file_url: z.string().url('Must be a valid URL'),
+  file_url: z.string().optional(),
   week_id: z.string().uuid().optional().or(z.literal('')),
   access_level: z.enum(['all', 'founders_only', 'aggiex_internal']),
   all_teams: z.boolean(),
@@ -32,6 +32,14 @@ const UploadSchema = z.object({
 });
 
 type UploadValues = z.infer<typeof UploadSchema>;
+type SourceMode = 'file' | 'url';
+
+function detectFileType(filename: string): AccelCurriculumFileType {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  if (ext === 'pdf') return 'pdf';
+  if (ext === 'docx' || ext === 'doc') return 'docx';
+  return 'other';
+}
 
 interface UploadCurriculumFormProps {
   weeks: Pick<AccelWeek, 'id' | 'week_number' | 'theme'>[];
@@ -40,6 +48,8 @@ interface UploadCurriculumFormProps {
 
 export default function UploadCurriculumForm({ weeks, teams }: UploadCurriculumFormProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [sourceMode, setSourceMode] = useState<SourceMode>('url');
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [serverError, setServerError] = useState<string | null>(null);
   const [addedTitle, setAddedTitle] = useState<string | null>(null);
 
@@ -62,6 +72,18 @@ export default function UploadCurriculumForm({ weeks, teams }: UploadCurriculumF
 
   const allTeams = watch('all_teams');
   const selectedTeamIds = watch('team_ids') ?? [];
+  const fileType = watch('file_type');
+  const isLinkType = fileType === 'video_link' || fileType === 'external_link';
+
+  useEffect(() => {
+    if (isLinkType) setSourceMode('url');
+  }, [isLinkType]);
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0] ?? null;
+    setSelectedFile(file);
+    if (file) setValue('file_type', detectFileType(file.name));
+  }
 
   const toggleTeam = (teamId: string) => {
     const next = selectedTeamIds.includes(teamId)
@@ -73,10 +95,44 @@ export default function UploadCurriculumForm({ weeks, teams }: UploadCurriculumF
   const onSubmit = async (values: UploadValues) => {
     setServerError(null);
 
+    let resolvedUrl: string;
+
+    if (sourceMode === 'file') {
+      if (!selectedFile) {
+        setServerError('Please select a file to upload.');
+        return;
+      }
+      const formData = new FormData();
+      formData.append('file', selectedFile);
+      const uploadResponse = await fetch('/api/upload/curriculum', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!uploadResponse.ok) {
+        const uploadData = await uploadResponse.json();
+        setServerError(uploadData.error ?? 'File upload failed.');
+        return;
+      }
+      const { publicUrl } = await uploadResponse.json();
+      resolvedUrl = publicUrl;
+    } else {
+      if (!values.file_url) {
+        setServerError('Please enter a URL.');
+        return;
+      }
+      try {
+        new URL(values.file_url);
+      } catch {
+        setServerError('Please enter a valid URL.');
+        return;
+      }
+      resolvedUrl = values.file_url;
+    }
+
     const payload: Record<string, unknown> = {
       title: values.title,
       file_type: values.file_type,
-      file_url: values.file_url,
+      file_url: resolvedUrl,
       access_level: values.access_level,
       assigned_team_ids: values.all_teams
         ? null
@@ -100,6 +156,7 @@ export default function UploadCurriculumForm({ weeks, teams }: UploadCurriculumF
 
     setAddedTitle(values.title);
     reset();
+    setSelectedFile(null);
     setIsOpen(false);
   };
 
@@ -127,7 +184,7 @@ export default function UploadCurriculumForm({ weeks, teams }: UploadCurriculumF
         <h3 className="text-sm font-semibold text-neutral-100">Add curriculum resource</h3>
         <button
           type="button"
-          onClick={() => { setIsOpen(false); setServerError(null); reset(); }}
+          onClick={() => { setIsOpen(false); setServerError(null); reset(); setSelectedFile(null); }}
           className="text-xs text-neutral-500 hover:text-neutral-300"
         >
           Cancel
@@ -183,17 +240,62 @@ export default function UploadCurriculumForm({ weeks, teams }: UploadCurriculumF
           </div>
         </div>
 
-        {/* URL */}
-        <div className="flex flex-col gap-1.5">
-          <label className={LABEL_CLASS}>URL</label>
-          <input
-            type="url"
-            {...register('file_url')}
-            placeholder="https://docs.google.com/... or https://youtube.com/..."
-            className={INPUT_CLASS}
-          />
-          {errors.file_url && <p className={ERROR_CLASS}>{errors.file_url.message}</p>}
-        </div>
+        {/* Source mode toggle (hidden for link-type resources) */}
+        {!isLinkType && (
+          <div className="flex overflow-hidden rounded-md border border-neutral-800 text-xs">
+            <button
+              type="button"
+              onClick={() => setSourceMode('file')}
+              className={`flex-1 py-1.5 transition-colors ${
+                sourceMode === 'file'
+                  ? 'bg-neutral-700 text-neutral-100'
+                  : 'text-neutral-500 hover:text-neutral-300'
+              }`}
+            >
+              Upload file
+            </button>
+            <button
+              type="button"
+              onClick={() => setSourceMode('url')}
+              className={`flex-1 py-1.5 transition-colors ${
+                sourceMode === 'url'
+                  ? 'bg-neutral-700 text-neutral-100'
+                  : 'text-neutral-500 hover:text-neutral-300'
+              }`}
+            >
+              Enter URL
+            </button>
+          </div>
+        )}
+
+        {/* File or URL input */}
+        {sourceMode === 'file' && !isLinkType ? (
+          <div className="flex flex-col gap-1.5">
+            <label className={LABEL_CLASS}>File (PDF or DOCX)</label>
+            <label className={`${INPUT_CLASS} flex cursor-pointer items-center gap-2`}>
+              <input
+                type="file"
+                className="sr-only"
+                accept=".pdf,.docx,.doc"
+                onChange={handleFileChange}
+              />
+              <span className={`truncate ${selectedFile ? 'text-neutral-100' : 'text-neutral-600'}`}>
+                {selectedFile ? selectedFile.name : 'Choose file…'}
+              </span>
+            </label>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1.5">
+            <label className={LABEL_CLASS}>URL</label>
+            <input
+              type="url"
+              {...register('file_url')}
+              placeholder="https://docs.google.com/... or https://youtube.com/..."
+              className={INPUT_CLASS}
+            />
+            {errors.file_url && <p className={ERROR_CLASS}>{errors.file_url.message}</p>}
+          </div>
+        )}
 
         {/* Role visibility */}
         <div className="flex flex-col gap-1.5">

--- a/my-app/app/api/accelerator/context-docs/route.ts
+++ b/my-app/app/api/accelerator/context-docs/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
 import { createClient } from '@/lib/supabase/server';
+import { extractTextFromBuffer } from '@/lib/ai/extract-file-text';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -77,23 +78,11 @@ async function extractTextFromFile(file: File): Promise<string> {
     throw new Error('File too large. Maximum upload size is 10 MB.');
   }
 
-  const arrayBuffer = await file.arrayBuffer();
-  const buffer = Buffer.from(arrayBuffer);
+  const buffer = Buffer.from(await file.arrayBuffer());
   const name = file.name.toLowerCase();
 
-  if (name.endsWith('.pdf')) {
-    // Dynamic import keeps this out of the client bundle entirely.
-    const { PDFParse } = await import('pdf-parse');
-    const parser = new PDFParse({ data: buffer });
-    const result = await parser.getText();
-    return result.text;
-  }
-
-  if (name.endsWith('.docx')) {
-    const mammoth = await import('mammoth');
-    const result = await mammoth.extractRawText({ buffer });
-    return result.value;
-  }
+  if (name.endsWith('.pdf')) return extractTextFromBuffer(buffer, 'pdf');
+  if (name.endsWith('.docx')) return extractTextFromBuffer(buffer, 'docx');
 
   // .txt / .md / .csv — plain UTF-8
   return buffer.toString('utf-8');

--- a/my-app/app/api/accelerator/curriculum/[id]/route.ts
+++ b/my-app/app/api/accelerator/curriculum/[id]/route.ts
@@ -1,7 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { z } from 'zod';
 import { requireAccelRole } from '@/lib/accel-auth';
 import { createClient } from '@/lib/supabase/server';
+import { embedCurriculumFile, deleteCurriculumFileEmbeddings } from '@/lib/ai/embedding-pipeline';
+
+const CONTENT_AFFECTING_FIELDS = new Set(['title', 'description', 'file_type', 'file_url', 'is_active']);
 
 const PatchCurriculumFileSchema = z.object({
   title: z.string().min(1).max(200).optional(),
@@ -54,6 +57,24 @@ export async function PATCH(
     return NextResponse.json({ error: dbError.message }, { status: 500 });
   }
 
+  const hasContentChange = Object.keys(parsed.data).some((field) =>
+    CONTENT_AFFECTING_FIELDS.has(field),
+  );
+
+  if (hasContentChange) {
+    after(async () => {
+      try {
+        if (parsed.data.is_active === false) {
+          await deleteCurriculumFileEmbeddings(id);
+        } else {
+          await embedCurriculumFile(id);
+        }
+      } catch (embedError) {
+        console.error('[curriculum] Background embedding update failed:', embedError);
+      }
+    });
+  }
+
   return NextResponse.json(data);
 }
 
@@ -76,6 +97,14 @@ export async function DELETE(
   if (dbError) {
     return NextResponse.json({ error: dbError.message }, { status: 500 });
   }
+
+  after(async () => {
+    try {
+      await deleteCurriculumFileEmbeddings(id);
+    } catch (embedError) {
+      console.error('[curriculum] Background embedding cleanup failed:', embedError);
+    }
+  });
 
   return new NextResponse(null, { status: 204 });
 }

--- a/my-app/app/api/accelerator/curriculum/route.ts
+++ b/my-app/app/api/accelerator/curriculum/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { z } from 'zod';
 import { requireAccelRole } from '@/lib/accel-auth';
 import { createClient } from '@/lib/supabase/server';
 import { AGGIEX_2026_PROGRAM_ID } from '@/lib/accel-types';
+import { embedCurriculumFile } from '@/lib/ai/embedding-pipeline';
 
 const CreateCurriculumFileSchema = z.object({
   title: z.string().min(1).max(200),
@@ -82,6 +83,14 @@ export async function POST(request: NextRequest) {
   if (dbError) {
     return NextResponse.json({ error: dbError.message }, { status: 500 });
   }
+
+  after(async () => {
+    try {
+      await embedCurriculumFile(data.id);
+    } catch (embedError) {
+      console.error('[curriculum] Background embedding failed:', embedError);
+    }
+  });
 
   return NextResponse.json(data, { status: 201 });
 }

--- a/my-app/app/api/upload/[bucket]/route.ts
+++ b/my-app/app/api/upload/[bucket]/route.ts
@@ -7,9 +7,10 @@ import type { NextRequest } from "next/server";
 
 export const runtime = "nodejs";
 
-const ALLOWED = ["avatars", "resumes", "project-logos", "project-images", "event-posters", "organization-logos", "organization-images", "internal-docs", "submissions"];
+const ALLOWED = ["avatars", "resumes", "project-logos", "project-images", "event-posters", "organization-logos", "organization-images", "internal-docs", "submissions", "curriculum"];
 
 const IMAGES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+const DOCS = ["application/pdf", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"];
 const ALLOWED_TYPES: Record<string, string[]> = {
   "avatars":            IMAGES,
   "project-logos":      [...IMAGES, "image/svg+xml"],
@@ -18,8 +19,9 @@ const ALLOWED_TYPES: Record<string, string[]> = {
   "organization-logos": [...IMAGES, "image/svg+xml"],
   "organization-images": IMAGES,
   "resumes":            ["application/pdf"],
-  "internal-docs":      ["application/pdf", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "text/plain"],
-  "submissions":        ["application/pdf", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "text/plain", ...IMAGES],
+  "internal-docs":      [...DOCS, "text/plain"],
+  "submissions":        [...DOCS, "text/plain", ...IMAGES],
+  "curriculum":         DOCS,
 };
 
 const storage = createStorageClient(

--- a/my-app/lib/ai/embedding-pipeline.ts
+++ b/my-app/lib/ai/embedding-pipeline.ts
@@ -14,10 +14,10 @@
  * in chunk count cleanly.
  */
 
-import crypto from 'crypto';
 import { createAdminClient } from '@/lib/supabase/accel-admin';
 import { embedBatch } from '@/lib/ai/embedder';
 import { chunkText } from '@/lib/ai/chunker';
+import { extractTextFromStorageUrl, md5 } from '@/lib/ai/extract-file-text';
 
 // ─── Submission sanitization ──────────────────────────────────────────────────
 //
@@ -78,10 +78,6 @@ export interface EmbedAllResult {
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────
-
-function md5(text: string): string {
-  return crypto.createHash('md5').update(text).digest('hex');
-}
 
 /**
  * Returns a map of source_id → content_hash for all existing rows in a source
@@ -154,7 +150,7 @@ async function replaceEmbeddings(
  */
 async function buildChunkedRows(
   source: EmbeddingSource,
-  documents: Array<{ id: string; fullText: string }>,
+  documents: Array<{ id: string; fullText: string; contentHash?: string }>,
 ): Promise<EmbeddingRow[]> {
   type FlatChunk = {
     sourceId: string;
@@ -167,7 +163,7 @@ async function buildChunkedRows(
 
   for (const doc of documents) {
     const chunks = chunkText(doc.fullText);
-    const contentHash = md5(doc.fullText);
+    const contentHash = doc.contentHash ?? md5(doc.fullText);
     for (let i = 0; i < chunks.length; i++) {
       flatChunks.push({ sourceId: doc.id, chunkIndex: i, chunkText: chunks[i], contentHash });
     }
@@ -191,13 +187,59 @@ async function buildChunkedRows(
 
 // ─── Source-specific embedders ────────────────────────────────────────────────
 
+// ─── Curriculum helpers ───────────────────────────────────────────────────────
+
+type CurriculumFileRow = {
+  id: string;
+  title: string;
+  description: string | null;
+  file_type: string;
+  file_url: string;
+};
+
+/**
+ * Hash used to detect changes without fetching file bytes on every sync run.
+ * For uploaded files (pdf/docx), the Supabase Storage URL acts as a content
+ * address — every upload generates a new UUID path, so URL change ≡ content
+ * change. For link-type resources, only title and description matter.
+ */
+function buildCurriculumHash(file: CurriculumFileRow): string {
+  const base = `${file.title}${file.description ? `: ${file.description}` : ''}`;
+  if (file.file_type === 'pdf' || file.file_type === 'docx') {
+    return md5(`${base}\n${file.file_url}`);
+  }
+  return md5(base);
+}
+
+async function buildCurriculumFullText(file: CurriculumFileRow): Promise<string> {
+  const base = `${file.title}${file.description ? `: ${file.description}` : ''}`;
+  if (file.file_type === 'pdf' || file.file_type === 'docx') {
+    try {
+      const extracted = await extractTextFromStorageUrl(
+        file.file_url,
+        file.file_type as 'pdf' | 'docx',
+      );
+      return extracted ? `${base}\n\n${extracted}` : base;
+    } catch (extractError) {
+      console.error(
+        `[embedding] Could not extract text from curriculum file ${file.file_url}:`,
+        extractError,
+      );
+      return base;
+    }
+  }
+  return base;
+}
+
+// ─── Source embedders ─────────────────────────────────────────────────────────
+
 async function embedCurriculumFiles(): Promise<EmbedSourceResult> {
   const source: EmbeddingSource = 'accel_curriculum_files';
   const supabase = createAdminClient();
 
   const { data: files, error } = await supabase
     .from('accel_curriculum_files')
-    .select('id, title, description')
+    .select('id, title, description, file_type, file_url')
     .eq('is_active', true);
 
   if (error) throw new Error(`Failed to fetch curriculum files: ${error.message}`);
@@ -205,17 +247,19 @@ async function embedCurriculumFiles(): Promise<EmbedSourceResult> {
 
   const existingHashes = await fetchExistingHashes(source);
 
-  const changed = files.filter((file) => {
-    const text = `${file.title}${file.description ? `: ${file.description}` : ''}`;
-    return existingHashes.get(file.id) !== md5(text);
-  });
+  const changed = files.filter(
+    (file) => existingHashes.get(file.id) !== buildCurriculumHash(file),
+  );
 
   if (changed.length === 0) return { source, upserted: 0, skipped: files.length };
 
-  const documents = changed.map((file) => ({
-    id: file.id,
-    fullText: `${file.title}${file.description ? `: ${file.description}` : ''}`,
-  }));
+  const documents = await Promise.all(
+    changed.map(async (file) => ({
+      id: file.id,
+      fullText: await buildCurriculumFullText(file),
+      contentHash: buildCurriculumHash(file),
+    })),
+  );
 
   const rows = await buildChunkedRows(source, documents);
   await replaceEmbeddings(source, changed.map((f) => f.id), rows);
@@ -352,6 +396,53 @@ async function embedContextDocs(): Promise<EmbedSourceResult> {
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Embeds a single curriculum file by ID. Used for immediate background indexing
+ * after upload without waiting for a full sync. Skips if the hash is unchanged.
+ */
+export async function embedCurriculumFile(fileId: string): Promise<void> {
+  const source: EmbeddingSource = 'accel_curriculum_files';
+  const supabase = createAdminClient();
+
+  const { data: file, error } = await supabase
+    .from('accel_curriculum_files')
+    .select('id, title, description, file_type, file_url, is_active')
+    .eq('id', fileId)
+    .single();
+
+  if (error || !file) {
+    console.error(`[embedding] Failed to fetch curriculum file ${fileId}:`, error?.message);
+    return;
+  }
+
+  if (!file.is_active) return;
+
+  const existingHashes = await fetchExistingHashes(source);
+  const newHash = buildCurriculumHash(file);
+  if (existingHashes.get(file.id) === newHash) return;
+
+  const fullText = await buildCurriculumFullText(file);
+  const rows = await buildChunkedRows(source, [{ id: file.id, fullText, contentHash: newHash }]);
+  await replaceEmbeddings(source, [file.id], rows);
+}
+
+/**
+ * Removes all embedding rows for a curriculum file. Called on hard-delete or
+ * when is_active is set to false so the file is immediately excluded from RAG.
+ */
+export async function deleteCurriculumFileEmbeddings(fileId: string): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from('accel_embeddings')
+    .delete()
+    .eq('source_table', 'accel_curriculum_files')
+    .eq('source_id', fileId);
+
+  if (error) {
+    console.error(`[embedding] Failed to delete embeddings for curriculum file ${fileId}:`, error.message);
+  }
+}
 
 /**
  * Re-embeds all five source tables in parallel. Idempotent: documents whose

--- a/my-app/lib/ai/extract-file-text.ts
+++ b/my-app/lib/ai/extract-file-text.ts
@@ -1,0 +1,48 @@
+import crypto from 'crypto';
+
+const MAX_EXTRACTED_CHARS = 200_000;
+
+export type ExtractableFileType = 'pdf' | 'docx';
+
+/**
+ * Extracts plain text from a Buffer using the file type to select the parser.
+ * PDF  → pdf-parse
+ * DOCX → mammoth
+ */
+export async function extractTextFromBuffer(
+  buffer: Buffer,
+  fileType: ExtractableFileType,
+): Promise<string> {
+  if (fileType === 'pdf') {
+    const { PDFParse } = await import('pdf-parse');
+    const parser = new PDFParse({ data: buffer });
+    const result = await parser.getText();
+    return result.text;
+  }
+
+  const mammoth = await import('mammoth');
+  const result = await mammoth.extractRawText({ buffer });
+  return result.value;
+}
+
+/**
+ * Fetches a file from a public storage URL, extracts its text, and returns it
+ * truncated to MAX_EXTRACTED_CHARS. Throws if the fetch fails.
+ */
+export async function extractTextFromStorageUrl(
+  url: string,
+  fileType: ExtractableFileType,
+): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file from storage: HTTP ${response.status}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const text = (await extractTextFromBuffer(buffer, fileType)).trim();
+  return text.length > MAX_EXTRACTED_CHARS ? text.slice(0, MAX_EXTRACTED_CHARS) : text;
+}
+
+export function md5(text: string): string {
+  return crypto.createHash('md5').update(text).digest('hex');
+}

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

**Curriculum file uploads**
- Staff can now upload PDFs and DOCXs directly from the Add Resource form instead of pasting an external URL
- Files land in Supabase Storage under a new `curriculum` bucket (PDF + DOCX MIME types only)
- The file type selector auto-detects from the uploaded file extension
- Toggle between \"Upload file\" and \"Enter URL\" — link-type resources (video, external link) stay URL-only

**AI embedding pipeline for curriculum content**
- Uploaded curriculum files are now indexed into the RAG pipeline automatically after upload via `next/server after()` — no manual sync required
- The AI Advisor can now answer questions about the actual content of uploaded slides and documents, not just their titles
- Hiding (`is_active=false`) or deleting a curriculum item immediately removes its embeddings in the background
- URL-based hash for change detection: unchanged files are skipped without re-fetching on full sync runs
- Shared `lib/ai/extract-file-text.ts` utility (pdf-parse + mammoth) used by both the pipeline and context-docs upload route

**Security fixes**
- Auth-gated `/api/search/*` routes that were previously unauthenticated
- AI rate limiting on the advisor endpoint
- Removed debug/test endpoints (`/api/debug`, `/api/test/auth`, `/admin/auth-monitoring`)
- Implemented CSO audit findings 2-4 + hardened session handling
- Removed `.gstack/` browse logs from the repository

**Other**
- Gemini 2.0 Flash → Gemini 2.5 Flash (model deprecation)
- MCP: fixed `keyId` destructuring in `requireAccelAuth` for MCP route handlers

## Test Coverage

No test suite configured in this project. Build passes cleanly (`✓ Compiled successfully`). Pre-landing review: no issues found in session changes.

Code paths covered by the implementation:
- File upload: file mode vs URL mode, link-type auto-switch to URL, file extension detection
- Embedding pipeline: hash check → skip unchanged, fetch+parse → chunk+embed → store, error fallback to metadata-only
- Cleanup: hide sets `is_active=false` → embedding delete; hard delete → embedding delete

## Pre-Landing Review

No issues found in the session's changes. Build compiles cleanly after all commits.

## Plan Completion

No formal plan file — changes implemented directly from conversation design.

## Test plan
- [ ] Upload a PDF curriculum resource and verify the file appears in Supabase Storage
- [ ] Confirm the AI Advisor can answer questions about the PDF's content after upload
- [ ] Hide a curriculum item and verify its embedding rows are removed on next query
- [ ] Delete a curriculum item and verify cleanup
- [ ] Verify link-type resources (Video Link, External Link) show URL input only

🤖 Generated with [Claude Code](https://claude.com/claude-code)