### PR TITLE
v0.1.2 feat: calendar event creation for AggieX staff + MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented here.
 ## [0.1.2] - 2026-06-09
 
 ### Added
+- Calendar event creation: AggieX staff can now add program events (speaker visits, demo days, social events, etc.) directly from the calendar page. Events support title, description, date, event type, visibility (all / founders / mentors / internal), and mandatory flag.
+- `add_program_event` staff MCP tool: AI assistants (Claude Desktop, Cursor, etc.) can now create calendar events via natural language with the standard confirm-gate pattern. Fully audit-logged.
 - Curriculum file upload: staff can now upload PDFs and DOCXs directly from the curriculum form instead of only entering URLs. Files are stored in Supabase Storage.
 - Automatic AI embedding of uploaded curriculum files: when a PDF or DOCX is uploaded as a curriculum resource, its full text content is extracted and indexed into the RAG pipeline automatically (via `next/server after()`). The AI Advisor can now answer questions about the actual content of uploaded slides and documents, not just their titles.
 - `lib/ai/extract-file-text.ts`: shared text extraction utility (pdf-parse, mammoth) used by both the embedding pipeline and the context-docs upload route.

--- a/my-app/app/accelerator/(platform)/calendar/components/add-event-panel.tsx
+++ b/my-app/app/accelerator/(platform)/calendar/components/add-event-panel.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Plus, X } from 'lucide-react';
+import type { AccelEventType, AccelVisibleTo } from '@/lib/accel-types';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const EVENT_TYPE_LABELS: Record<AccelEventType, string> = {
+  speaker_day: 'Speaker Day',
+  demo_day: 'Demo Day',
+  final_demo_day: 'Final Demo Day',
+  social_event: 'Social Event',
+  mentor_day: 'Mentor Day',
+  one_on_one: '1-on-1 Sessions',
+  crucible: 'Crucible',
+  week_start: 'Week Start',
+  week_end: 'Week End',
+  off_day: 'Off Day',
+  program_close: 'Program Close',
+};
+
+const VISIBLE_TO_LABELS: Record<AccelVisibleTo, string> = {
+  all: 'Everyone (founders, mentors, staff)',
+  founders: 'Founders + staff',
+  mentors: 'Mentors + staff',
+  aggiex_team: 'AggieX internal only',
+};
+
+const EVENT_TYPE_OPTIONS = Object.keys(EVENT_TYPE_LABELS) as AccelEventType[];
+const VISIBLE_TO_OPTIONS = Object.keys(VISIBLE_TO_LABELS) as AccelVisibleTo[];
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function AddEventPanel() {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [eventType, setEventType] = useState<AccelEventType>('speaker_day');
+  const [eventDate, setEventDate] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [isMandatory, setIsMandatory] = useState(false);
+  const [visibleTo, setVisibleTo] = useState<AccelVisibleTo>('all');
+
+  function reset() {
+    setEventType('speaker_day');
+    setEventDate('');
+    setTitle('');
+    setDescription('');
+    setIsMandatory(false);
+    setVisibleTo('all');
+    setError(null);
+  }
+
+  function close() {
+    reset();
+    setIsOpen(false);
+  }
+
+  async function submit() {
+    if (!eventDate || !title.trim()) {
+      setError('Date and title are required.');
+      return;
+    }
+
+    setIsPending(true);
+    setError(null);
+
+    const response = await fetch('/api/accelerator/program-events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event_type: eventType,
+        event_date: eventDate,
+        title: title.trim(),
+        description: description.trim() || null,
+        is_mandatory: isMandatory,
+        visible_to: visibleTo,
+      }),
+    });
+
+    setIsPending(false);
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      setError(body.error ?? 'Failed to create event.');
+      return;
+    }
+
+    close();
+    router.refresh();
+  }
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="flex items-center gap-1.5 rounded-md bg-neutral-800 px-3 py-2 text-xs
+          font-medium text-neutral-200 hover:bg-neutral-700 transition-colors"
+      >
+        <Plus size={13} />
+        Add event
+      </button>
+    );
+  }
+
+  return (
+    <div className="mb-6 rounded-lg border border-neutral-700 bg-neutral-900 p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <p className="text-sm font-medium text-neutral-200">Add program event</p>
+        <button onClick={close} className="text-neutral-600 hover:text-neutral-400">
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {/* Event type */}
+        <div>
+          <label className="mb-1 block text-xs text-neutral-500">Event type</label>
+          <select
+            value={eventType}
+            onChange={(e) => setEventType(e.target.value as AccelEventType)}
+            className={SELECT_CLASS}
+          >
+            {EVENT_TYPE_OPTIONS.map((type) => (
+              <option key={type} value={type}>{EVENT_TYPE_LABELS[type]}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Date */}
+        <div>
+          <label className="mb-1 block text-xs text-neutral-500">Date</label>
+          <input
+            type="date"
+            value={eventDate}
+            onChange={(e) => setEventDate(e.target.value)}
+            className={INPUT_CLASS}
+          />
+        </div>
+
+        {/* Title */}
+        <div className="sm:col-span-2">
+          <label className="mb-1 block text-xs text-neutral-500">Title</label>
+          <input
+            type="text"
+            placeholder="e.g. Sarah Chen (a16z) — Fundraising Strategy"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={200}
+            className={INPUT_CLASS}
+          />
+        </div>
+
+        {/* Description */}
+        <div className="sm:col-span-2">
+          <label className="mb-1 block text-xs text-neutral-500">
+            Description <span className="text-neutral-600">(optional)</span>
+          </label>
+          <textarea
+            rows={3}
+            placeholder="Who will be there, what to expect, logistics, links…"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className={`${INPUT_CLASS} resize-none`}
+          />
+        </div>
+
+        {/* Visible to */}
+        <div>
+          <label className="mb-1 block text-xs text-neutral-500">Visible to</label>
+          <select
+            value={visibleTo}
+            onChange={(e) => setVisibleTo(e.target.value as AccelVisibleTo)}
+            className={SELECT_CLASS}
+          >
+            {VISIBLE_TO_OPTIONS.map((v) => (
+              <option key={v} value={v}>{VISIBLE_TO_LABELS[v]}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Mandatory */}
+        <div className="flex items-end pb-2">
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-neutral-300">
+            <input
+              type="checkbox"
+              checked={isMandatory}
+              onChange={(e) => setIsMandatory(e.target.checked)}
+              className="accent-neutral-100"
+            />
+            Mark as mandatory
+          </label>
+        </div>
+      </div>
+
+      {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
+
+      <div className="mt-4 flex justify-end gap-2">
+        <button onClick={close} className="text-xs text-neutral-500 hover:text-neutral-300">
+          Cancel
+        </button>
+        <button
+          onClick={submit}
+          disabled={isPending}
+          className="rounded-md bg-neutral-100 px-4 py-2 text-xs font-medium text-neutral-900
+            hover:bg-white disabled:opacity-50 transition-colors"
+        >
+          {isPending ? 'Saving…' : 'Add event'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const INPUT_CLASS =
+  'w-full rounded-md border border-neutral-800 bg-neutral-950 px-2.5 py-2 text-sm ' +
+  'text-neutral-100 placeholder:text-neutral-700 focus:outline-none';
+
+const SELECT_CLASS =
+  'w-full rounded-md border border-neutral-800 bg-neutral-950 px-2.5 py-2 text-sm ' +
+  'text-neutral-100 focus:outline-none';

--- a/my-app/app/accelerator/(platform)/calendar/page.tsx
+++ b/my-app/app/accelerator/(platform)/calendar/page.tsx
@@ -14,6 +14,7 @@ import AcceleratorCalendarView, {
   type CalendarWeek,
   type CalendarCurriculumFile,
 } from './components/accelerator-calendar-view';
+import AddEventPanel from './components/add-event-panel';
 
 // ─── Data fetchers ────────────────────────────────────────────────────────────
 
@@ -353,14 +354,17 @@ export default async function CalendarPage() {
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-8">
-      <div className="mb-8">
-        <p className="text-xs uppercase tracking-widest text-neutral-500">Program</p>
-        <h1 className="mt-1 text-xl font-semibold text-neutral-100">Calendar</h1>
-        <p className="mt-0.5 text-sm text-neutral-500">
-          {role === 'founder'
-            ? 'Deliverable due dates, curriculum resources, and program events.'
-            : 'Submission progress per team, curriculum, and program events.'}
-        </p>
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-widest text-neutral-500">Program</p>
+          <h1 className="mt-1 text-xl font-semibold text-neutral-100">Calendar</h1>
+          <p className="mt-0.5 text-sm text-neutral-500">
+            {role === 'founder'
+              ? 'Deliverable due dates, curriculum resources, and program events.'
+              : 'Submission progress per team, curriculum, and program events.'}
+          </p>
+        </div>
+        {role === 'aggiex_team' && <AddEventPanel />}
       </div>
 
       <AcceleratorCalendarView

--- a/my-app/app/api/accelerator/program-events/route.ts
+++ b/my-app/app/api/accelerator/program-events/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAccelRole } from '@/lib/accel-auth';
+import { createClient } from '@/lib/supabase/server';
+import { AGGIEX_2026_PROGRAM_ID } from '@/lib/accel-types';
+
+const CreateProgramEventSchema = z.object({
+  event_type: z.enum([
+    'week_start', 'week_end', 'demo_day', 'crucible', 'speaker_day',
+    'mentor_day', 'off_day', 'one_on_one', 'social_event', 'final_demo_day', 'program_close',
+  ]),
+  event_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be YYYY-MM-DD'),
+  title: z.string().min(1).max(200),
+  description: z.string().max(2000).nullable().optional(),
+  is_mandatory: z.boolean().default(false),
+  visible_to: z.enum(['all', 'founders', 'mentors', 'aggiex_team']).default('all'),
+  week_number: z.number().int().min(1).max(10).nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const { profile, error } = await requireAccelRole(['aggiex_team']);
+  if (error) return error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = CreateProgramEventSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  const { data, error: dbError } = await supabase
+    .from('accel_program_events')
+    .insert({
+      ...parsed.data,
+      program_id: AGGIEX_2026_PROGRAM_ID,
+      created_by: profile.id,
+    })
+    .select()
+    .single();
+
+  if (dbError) {
+    if (dbError.code === '23505') {
+      return NextResponse.json(
+        { error: 'An event of this type already exists on that date.' },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json({ error: dbError.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data, { status: 201 });
+}

--- a/my-app/app/api/mcp/tools.ts
+++ b/my-app/app/api/mcp/tools.ts
@@ -198,6 +198,56 @@ export const STAFF_TOOLS = [
     },
   },
   {
+    name: 'add_program_event',
+    description:
+      'Create a program event visible on the calendar — speaker visits, demo days, social events, etc. ' +
+      'Pass confirm: true to execute; omit or pass confirm: false to preview what would be created.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        event_type: {
+          type: 'string',
+          enum: [
+            'speaker_day', 'demo_day', 'final_demo_day', 'social_event',
+            'mentor_day', 'one_on_one', 'crucible', 'week_start', 'week_end',
+            'off_day', 'program_close',
+          ],
+          description: 'Category of the event',
+        },
+        event_date: {
+          type: 'string',
+          description: 'Date of the event in YYYY-MM-DD format',
+        },
+        title: {
+          type: 'string',
+          description: 'Event title shown on the calendar (max 200 chars)',
+        },
+        description: {
+          type: 'string',
+          description: 'Details about the event — who is attending, agenda, logistics, links (max 2000 chars)',
+        },
+        is_mandatory: {
+          type: 'boolean',
+          description: 'Whether attendance is mandatory for founders (default false)',
+        },
+        visible_to: {
+          type: 'string',
+          enum: ['all', 'founders', 'mentors', 'aggiex_team'],
+          description: 'Who can see this event (default: all)',
+        },
+        week_number: {
+          type: 'number',
+          description: 'Optional week number (1–10) this event belongs to',
+        },
+        confirm: {
+          type: 'boolean',
+          description: 'Set to true to execute. Omit or false to preview what would be created.',
+        },
+      },
+      required: ['event_type', 'event_date', 'title'],
+    },
+  },
+  {
     name: 'get_recent_activity',
     description: 'Return the last 50 write-tool calls made via the staff MCP — who called what, when, and the result. Use for auditing or debugging.',
     inputSchema: {
@@ -233,7 +283,7 @@ async function writeAuditLog(
 
 // ─── Tool implementations ────────────────────────────────────────────────────
 
-const WRITE_TOOLS = new Set(['add_deliverable', 'update_submission_status', 'unlock_week', 'create_curriculum_item', 'add_internal_doc']);
+const WRITE_TOOLS = new Set(['add_deliverable', 'update_submission_status', 'unlock_week', 'create_curriculum_item', 'add_internal_doc', 'add_program_event']);
 
 export async function handleToolCall(
   name: string,
@@ -275,7 +325,7 @@ async function dispatch(
       name: profile.full_name,
       role: profile.role,
       available_tools: STAFF_TOOLS.map((t) => t.name),
-      note: 'Write tools (add_deliverable, update_submission_status, unlock_week) require confirm: true to execute.',
+      note: 'Write tools (add_deliverable, update_submission_status, unlock_week, add_program_event) require confirm: true to execute.',
     });
   }
 
@@ -562,6 +612,64 @@ async function dispatch(
 
     if (error) throw new Error(error.message);
     return text(`Internal doc created: "${data.title}" (${data.id})`);
+  }
+
+  if (name === 'add_program_event') {
+    const confirm = args.confirm === true;
+
+    const EVENT_TYPE_LABELS: Record<string, string> = {
+      speaker_day: 'Speaker Day', demo_day: 'Demo Day', final_demo_day: 'Final Demo Day',
+      social_event: 'Social Event', mentor_day: 'Mentor Day', one_on_one: '1-on-1 Sessions',
+      crucible: 'Crucible', week_start: 'Week Start', week_end: 'Week End',
+      off_day: 'Off Day', program_close: 'Program Close',
+    };
+
+    const preview = {
+      event_type: EVENT_TYPE_LABELS[args.event_type as string] ?? args.event_type,
+      event_date: args.event_date,
+      title: args.title,
+      description: args.description ?? null,
+      is_mandatory: args.is_mandatory ?? false,
+      visible_to: args.visible_to ?? 'all',
+      week_number: args.week_number ?? null,
+    };
+
+    if (!confirm) {
+      return text({ preview, action: 'Call again with confirm: true to create this event.' });
+    }
+
+    const { data: program } = await admin
+      .from('accel_programs')
+      .select('id')
+      .eq('is_active', true)
+      .single();
+
+    if (!program) throw new Error('No active program found.');
+
+    const { data, error } = await admin
+      .from('accel_program_events')
+      .insert({
+        program_id: program.id,
+        event_type: args.event_type as string,
+        event_date: args.event_date as string,
+        title: args.title as string,
+        description: (args.description as string) ?? null,
+        is_mandatory: (args.is_mandatory as boolean) ?? false,
+        visible_to: (args.visible_to as string) ?? 'all',
+        week_number: (args.week_number as number) ?? null,
+        created_by: profile.id,
+      })
+      .select('id, title, event_date')
+      .single();
+
+    if (error) {
+      if (error.code === '23505') {
+        throw new Error(`An event of type "${args.event_type}" already exists on ${args.event_date}.`);
+      }
+      throw new Error(error.message);
+    }
+
+    return text(`Event created: "${data.title}" on ${data.event_date} (${data.id})`);
   }
 
   if (name === 'get_recent_activity') {

--- a/supabase/migrations/20260609000001_curriculum_storage.sql
+++ b/supabase/migrations/20260609000001_curriculum_storage.sql
@@ -1,0 +1,35 @@
+-- ============================================================
+-- Curriculum Storage Bucket
+-- Created: 2026-06-09
+-- ============================================================
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('curriculum', 'curriculum', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Allow aggiex_team and mce_staff to upload curriculum files
+CREATE POLICY "curriculum_storage_upload"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'curriculum'
+    AND EXISTS (
+      SELECT 1 FROM accel_profiles
+      WHERE id = auth.uid() AND role IN ('aggiex_team', 'mce_staff')
+    )
+  );
+
+-- Allow public read so file URLs work without auth
+CREATE POLICY "curriculum_storage_read"
+  ON storage.objects FOR SELECT TO public
+  USING (bucket_id = 'curriculum');
+
+-- Allow aggiex_team to delete files
+CREATE POLICY "curriculum_storage_delete"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'curriculum'
+    AND EXISTS (
+      SELECT 1 FROM accel_profiles
+      WHERE id = auth.uid() AND role = 'aggiex_team'
+    )
+  );


### PR DESCRIPTION
## Summary

**Calendar event creation**
- AggieX staff now have an \"Add event\" button in the top-right of the Calendar page (visible to aggiex_team only)
- Form fields: event type (11 types: Speaker Day, Demo Day, Final Demo Day, Social Event, Mentor Day, 1-on-1, Crucible, etc.), date, title, description (for who's attending, agenda, links), visibility (everyone / founders / mentors / AggieX internal), and mandatory checkbox
- Events appear immediately in the calendar after creation via \`router.refresh()\`
- Duplicate event type + date returns a clear 409 error rather than a DB crash

**\`add_program_event\` staff MCP tool**
- AI assistants connected to the staff MCP (Claude Desktop, Cursor, etc.) can now create calendar events via natural language
- Follows the standard confirm-gate pattern: call without \`confirm: true\` for a preview, call again with \`confirm: true\` to create
- Fully audit-logged via \`WRITE_TOOLS\` — every call lands in \`accel_mcp_audit_log\`
- Example: *"Add a speaker event on June 20 — Sarah Chen from a16z, open to all founders and mentors, mandatory"*

**Supabase Storage: curriculum bucket**
- Migration \`20260609000001_curriculum_storage.sql\` creates the \`curriculum\` bucket with upload (aggiex_team + mce_staff), read (public), and delete (aggiex_team) policies
- Fixes the 500 \`Bucket not found\` error on curriculum file uploads

## Pre-Landing Review

No issues found. Build compiles cleanly (\`✓ Compiled successfully\`).

## Test plan
- [ ] Navigate to Calendar page as aggiex_team — confirm \"Add event\" button appears
- [ ] Create a Speaker Day event and verify it appears on the calendar
- [ ] Verify founders/mentors cannot see the Add Event button
- [ ] Test the MCP tool: call \`add_program_event\` without \`confirm: true\` to see preview, then with \`confirm: true\` to create
- [ ] Verify created event appears in \`get_recent_activity\` audit log
- [ ] Upload a curriculum PDF and verify no 500 error (bucket now exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)