### PR TITLE
feat: team-scoped context + cohort-abstracted RAG

### DIFF
--- a/my-app/app/api/accelerator/ai-advisor/route.ts
+++ b/my-app/app/api/accelerator/ai-advisor/route.ts
@@ -118,12 +118,16 @@ export async function POST(request: NextRequest) {
     .join(' ')
     .trim() ?? '';
 
+  // Founders get their own team's private content + shared content.
+  // Staff/mentors get no filter — they can see across all teams.
+  const semanticTeamId = profile.role === 'founder' ? (profile.team_id ?? undefined) : undefined;
+
   let systemPrompt: string;
   let semanticContext: string;
   try {
     [systemPrompt, semanticContext] = await Promise.all([
       buildSystemPrompt(user.id, profile.role as AccelRole),
-      buildSemanticContext(lastUserText),
+      buildSemanticContext(lastUserText, semanticTeamId),
     ]);
   } catch (error) {
     console.error('[ai-advisor] Context build failed:', error);

--- a/my-app/app/api/mcp/tools.ts
+++ b/my-app/app/api/mcp/tools.ts
@@ -2,6 +2,8 @@ import { createGroq } from '@ai-sdk/groq';
 import { generateText } from 'ai';
 import { createAdminClient } from '@/lib/supabase/accel-admin';
 import type { AccelProfile } from '@/lib/accel-types';
+import { embedTeamContextEntry } from '@/lib/ai/embedding-pipeline';
+import { deriveAndStoreCohortLesson } from '@/lib/ai/cohort-abstraction';
 
 const groq = createGroq({ apiKey: process.env.GROQ_API_KEY });
 
@@ -258,6 +260,27 @@ export const STAFF_TOOLS = [
       required: [],
     },
   },
+  {
+    name: 'upsert_team_context',
+    description:
+      'Set or update a structured context field for a specific team — ICP, market hypothesis, beachhead, solution description, traction narrative, or any custom key. ' +
+      'Content is immediately indexed into the AI advisor knowledge base for that team. ' +
+      'Because you are staff, this also triggers cohort abstraction: the insight is generalized and added to the shared cohort knowledge pool. ' +
+      'Pass confirm: true to execute; omit or false to preview.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        team_name: { type: 'string', description: 'Team name (partial match supported)' },
+        context_key: {
+          type: 'string',
+          description: 'Context type: icp, market_hypothesis, beachhead, solution, traction_narrative, notes, or any custom label',
+        },
+        content: { type: 'string', description: 'The context content to store' },
+        confirm: { type: 'boolean', description: 'Set true to execute; omit to preview' },
+      },
+      required: ['team_name', 'context_key', 'content'],
+    },
+  },
 ];
 
 // ─── Audit logging ───────────────────────────────────────────────────────────
@@ -283,7 +306,7 @@ async function writeAuditLog(
 
 // ─── Tool implementations ────────────────────────────────────────────────────
 
-const WRITE_TOOLS = new Set(['add_deliverable', 'update_submission_status', 'unlock_week', 'create_curriculum_item', 'add_internal_doc', 'add_program_event']);
+const WRITE_TOOLS = new Set(['add_deliverable', 'update_submission_status', 'unlock_week', 'create_curriculum_item', 'add_internal_doc', 'add_program_event', 'upsert_team_context']);
 
 export async function handleToolCall(
   name: string,
@@ -685,6 +708,63 @@ async function dispatch(
 
     if (error) throw new Error(error.message);
     return text(data ?? []);
+  }
+
+  if (name === 'upsert_team_context') {
+    const confirm = args.confirm === true;
+
+    const { data: teams, error: teamError } = await admin
+      .from('accel_teams')
+      .select('id, name')
+      .ilike('name', `%${args.team_name as string}%`)
+      .eq('is_active', true)
+      .limit(3);
+
+    if (teamError) throw new Error(teamError.message);
+    if (!teams?.length) throw new Error(`No active team found matching "${args.team_name}"`);
+    if (teams.length > 1) {
+      throw new Error(
+        `Multiple teams match "${args.team_name}": ${teams.map((t) => t.name).join(', ')} — be more specific`,
+      );
+    }
+
+    const team = teams[0];
+    const preview = {
+      team: team.name,
+      context_key: args.context_key,
+      content: args.content,
+      updated_by: 'aggiex_team',
+      source: 'mcp',
+    };
+
+    if (!confirm) {
+      return text({ preview, action: 'Call again with confirm: true to save.' });
+    }
+
+    const { error } = await admin
+      .from('accel_team_context')
+      .upsert(
+        {
+          team_id: team.id,
+          context_key: args.context_key as string,
+          content: args.content as string,
+          updated_by: 'aggiex_team',
+          source: 'mcp',
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'team_id,context_key' },
+      );
+
+    if (error) throw new Error(error.message);
+
+    // Fire-and-forget: embed new content and derive cohort lesson in background
+    embedTeamContextEntry(team.id, args.context_key as string, args.content as string)
+      .catch((err: Error) => console.error('[upsert_team_context] embed error:', err));
+
+    deriveAndStoreCohortLesson(team.id, args.context_key as string, args.content as string)
+      .catch((err: Error) => console.error('[upsert_team_context] cohort abstraction error:', err));
+
+    return text(`Team context saved: ${team.name} → ${args.context_key}`);
   }
 
   return text(`Unknown tool: ${name}`);

--- a/my-app/lib/ai/advisor-tools.ts
+++ b/my-app/lib/ai/advisor-tools.ts
@@ -1,11 +1,10 @@
-// Tool definitions for the AI Advisor agent.
-// All tools are read-only — writes are handled by the existing extraction + ActionCard flow.
-
 import { tool } from 'ai';
 import { z } from 'zod';
 import { handleFounderToolCall } from '@/app/api/mcp/founder/tools';
 import { handleToolCall } from '@/app/api/mcp/tools';
 import { getRedis } from '@/lib/redis';
+import { createAdminClient } from '@/lib/supabase/accel-admin';
+import { embedTeamContextEntry } from '@/lib/ai/embedding-pipeline';
 import type { AccelProfile } from '@/lib/accel-types';
 
 function firstText(content: Array<{ type: 'text'; text: string }>): string {
@@ -51,6 +50,41 @@ export function buildFounderAdvisorTools(profile: AccelProfile) {
       execute: async (args) => {
         const { week_number } = args ?? {};
         return firstText(await handleFounderToolCall('get_curriculum', { week_number }, profile));
+      },
+    }),
+
+    update_company_context: tool({
+      description:
+        'Save structured information about your company — ICP, market hypothesis, beachhead segment, solution description, or any label — so the advisor remembers it across sessions.',
+      parameters: z.object({
+        context_key: z
+          .string()
+          .describe('What type of information: icp, market_hypothesis, beachhead, solution, notes, or any label'),
+        content: z.string().describe('The information to save'),
+      }),
+      execute: async (args) => {
+        const { context_key, content } = args ?? {};
+        if (!profile.team_id) return 'No team assigned — cannot save context.';
+        const admin = createAdminClient();
+        const { error } = await admin.from('accel_team_context').upsert(
+          {
+            team_id: profile.team_id,
+            context_key,
+            content,
+            updated_by: 'founder',
+            source: 'ai_advisor',
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: 'team_id,context_key' },
+        );
+        if (error) throw new Error(`Failed to save context: ${error.message}`);
+        embedTeamContextEntry(profile.team_id, context_key, content)
+          .catch((err: Error) => console.error('[update_company_context] embed error:', err));
+        const redis = getRedis();
+        if (redis) {
+          redis.del(`accel:ctx:founder:${profile.id}`).catch(() => {});
+        }
+        return `Saved "${context_key}" to your company profile. I'll reference this in future sessions.`;
       },
     }),
 
@@ -147,6 +181,21 @@ export function buildStaffAdvisorTools(profile: AccelProfile) {
         doc_type: z.string().optional(),
       }),
       execute: async (args) => call('add_internal_doc', args ?? {}),
+    }),
+
+    upsert_team_context: tool({
+      description:
+        'Set or update a context field for a specific team (ICP, market hypothesis, beachhead, solution, etc.). ' +
+        'As staff, this also triggers cohort abstraction — the insight is generalized and added to the shared knowledge pool.',
+      parameters: z.object({
+        team_name: z.string().describe('Team name (partial match supported)'),
+        context_key: z
+          .string()
+          .describe('Context type: icp, market_hypothesis, beachhead, solution, traction_narrative, notes, or custom label'),
+        content: z.string().describe('The context content'),
+        confirm: z.boolean().optional().describe('Set true to execute; omit to preview'),
+      }),
+      execute: async (args) => call('upsert_team_context', args ?? {}),
     }),
   };
 }

--- a/my-app/lib/ai/cohort-abstraction.ts
+++ b/my-app/lib/ai/cohort-abstraction.ts
@@ -1,0 +1,58 @@
+import { createGroq } from '@ai-sdk/groq';
+import { generateText } from 'ai';
+import { createAdminClient } from '@/lib/supabase/accel-admin';
+import { md5 } from '@/lib/ai/extract-file-text';
+
+const groq = createGroq({ apiKey: process.env.GROQ_API_KEY });
+
+async function abstractToLesson(
+  contextKey: string,
+  content: string,
+  teamVertical: string | null,
+): Promise<string> {
+  const verticalHint = teamVertical ? ` working in ${teamVertical}` : '';
+
+  const { text } = await generateText({
+    model: groq('llama-3.3-70b-versatile'),
+    temperature: 0.3,
+    prompt: `You are extracting a generalizable cohort lesson from a startup's private company context.
+
+CONTEXT TYPE: ${contextKey}
+CONTENT: ${content}
+
+Rewrite this as a cohort insight that:
+1. Removes all identifying details (company name, founder names, specific product names, unique metrics)
+2. Preserves the strategic pattern or insight
+3. Uses "a cohort team${verticalHint}" or "one team" as the subject
+4. Is useful for other founders at the same stage
+5. Is 2-4 sentences maximum
+
+Output only the lesson text — no preamble, no labels.`,
+  });
+
+  return text.trim();
+}
+
+export async function deriveAndStoreCohortLesson(
+  teamId: string,
+  contextKey: string,
+  content: string,
+): Promise<void> {
+  const admin = createAdminClient();
+
+  const { data: team } = await admin
+    .from('accel_teams')
+    .select('industry_vertical')
+    .eq('id', teamId)
+    .single();
+
+  const lessonText = await abstractToLesson(contextKey, content, team?.industry_vertical ?? null);
+  const contentHash = md5(lessonText);
+
+  await admin
+    .from('accel_cohort_lessons')
+    .upsert(
+      { lesson_text: lessonText, context_key: contextKey, content_hash: contentHash },
+      { onConflict: 'content_hash', ignoreDuplicates: true },
+    );
+}

--- a/my-app/lib/ai/context-builder.ts
+++ b/my-app/lib/ai/context-builder.ts
@@ -80,6 +80,7 @@ async function buildFounderContext(userId: string): Promise<string> {
     tractionResult,
     meetingsResult,
     upcomingEventsResult,
+    teamContextResult,
   ] = await Promise.all([
     supabase.from('accel_teams').select('name, industry_vertical, venture_stage').eq('id', teamId).single(),
 
@@ -122,6 +123,12 @@ async function buildFounderContext(userId: string): Promise<string> {
       .in('visible_to', ['all', 'founders'])
       .order('event_date')
       .limit(5),
+
+    supabase
+      .from('accel_team_context')
+      .select('context_key, content')
+      .eq('team_id', teamId)
+      .order('context_key'),
   ]);
 
   const team = teamResult.data;
@@ -213,10 +220,18 @@ async function buildFounderContext(userId: string): Promise<string> {
     `CURRENT USER: ${profile.full_name}`,
     currentWeek ? `CURRENT WEEK: Week ${currentWeek.week_number} — ${currentWeek.theme}` : 'No active week.',
     '',
-    '## DELIVERABLES',
-    ...deliverableLines,
-    '',
   ];
+
+  const teamContext = teamContextResult.data ?? [];
+  if (teamContext.length) {
+    lines.push('## COMPANY PROFILE');
+    for (const ctx of teamContext) {
+      lines.push(`  ${ctx.context_key}: ${ctx.content}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## DELIVERABLES', ...deliverableLines, '');
 
   const mentors = mentorsResult.data ?? [];
   if (mentors.length) {
@@ -275,7 +290,7 @@ async function buildFounderContext(userId: string): Promise<string> {
 async function buildAdminContext(): Promise<string> {
   const supabase = await createClient();
 
-  const [teamsResult, currentWeekResult, tractionResult, mentorsResult, fundingEventsResult] =
+  const [teamsResult, currentWeekResult, tractionResult, mentorsResult, fundingEventsResult, teamContextsResult] =
     await Promise.all([
       supabase
         .from('accel_teams')
@@ -310,6 +325,11 @@ async function buildAdminContext(): Promise<string> {
         .eq('program_id', AGGIEX_2026_PROGRAM_ID)
         .order('acquired_at', { ascending: false })
         .limit(50),
+
+      supabase
+        .from('accel_team_context')
+        .select('team_id, context_key, content')
+        .order('context_key'),
     ]);
 
   const teams = teamsResult.data ?? [];
@@ -342,6 +362,14 @@ async function buildAdminContext(): Promise<string> {
         });
       }
     }
+  }
+
+  // Team context grouped by team_id
+  const contextByTeam = new Map<string, Array<{ context_key: string; content: string }>>();
+  for (const ctx of teamContextsResult.data ?? []) {
+    const existing = contextByTeam.get(ctx.team_id) ?? [];
+    existing.push({ context_key: ctx.context_key, content: ctx.content });
+    contextByTeam.set(ctx.team_id, existing);
   }
 
   // Latest traction per metric per team
@@ -387,6 +415,14 @@ async function buildAdminContext(): Promise<string> {
       }
     } else {
       lines.push(`  Traction: no entries logged`);
+    }
+
+    const teamContextEntries = contextByTeam.get(team.id) ?? [];
+    if (teamContextEntries.length) {
+      lines.push(`  Company profile:`);
+      for (const ctx of teamContextEntries) {
+        lines.push(`    - ${ctx.context_key}: ${ctx.content}`);
+      }
     }
   }
 
@@ -1072,7 +1108,7 @@ type HybridMatch = {
  * Returns a formatted block ready to append to the system prompt, or an
  * empty string if Jina is unconfigured, the query is empty, or nothing matches.
  */
-export async function buildSemanticContext(query: string): Promise<string> {
+export async function buildSemanticContext(query: string, teamId?: string): Promise<string> {
   if (!query.trim()) return '';
   if (!process.env.JINA_API_KEY) return '';
 
@@ -1093,6 +1129,7 @@ export async function buildSemanticContext(query: string): Promise<string> {
     query_embedding: queryVector,
     query_text: query,
     match_count: HYBRID_CANDIDATE_COUNT,
+    p_team_id: teamId ?? null,
   });
 
   if (rpcError) {

--- a/my-app/lib/ai/embedding-pipeline.ts
+++ b/my-app/lib/ai/embedding-pipeline.ts
@@ -52,7 +52,9 @@ type EmbeddingSource =
   | 'accel_deliverables'
   | 'accel_submissions'
   | 'accel_meeting_records'
-  | 'accel_context_docs';
+  | 'accel_context_docs'
+  | 'accel_team_context'
+  | 'accel_cohort_lessons';
 
 interface EmbeddingRow {
   source_table: EmbeddingSource;
@@ -62,6 +64,7 @@ interface EmbeddingRow {
   content_hash: string;
   embedding: number[];
   embedded_at: string;
+  team_id: string | null;
 }
 
 export interface EmbedSourceResult {
@@ -150,13 +153,14 @@ async function replaceEmbeddings(
  */
 async function buildChunkedRows(
   source: EmbeddingSource,
-  documents: Array<{ id: string; fullText: string; contentHash?: string }>,
+  documents: Array<{ id: string; fullText: string; contentHash?: string; teamId?: string | null }>,
 ): Promise<EmbeddingRow[]> {
   type FlatChunk = {
     sourceId: string;
     chunkIndex: number;
     chunkText: string;
     contentHash: string;
+    teamId: string | null;
   };
 
   const flatChunks: FlatChunk[] = [];
@@ -165,7 +169,13 @@ async function buildChunkedRows(
     const chunks = chunkText(doc.fullText);
     const contentHash = doc.contentHash ?? md5(doc.fullText);
     for (let i = 0; i < chunks.length; i++) {
-      flatChunks.push({ sourceId: doc.id, chunkIndex: i, chunkText: chunks[i], contentHash });
+      flatChunks.push({
+        sourceId: doc.id,
+        chunkIndex: i,
+        chunkText: chunks[i],
+        contentHash,
+        teamId: doc.teamId ?? null,
+      });
     }
   }
 
@@ -182,6 +192,7 @@ async function buildChunkedRows(
     content_hash: chunk.contentHash,
     embedding: embedded[i].vector,
     embedded_at: now,
+    team_id: chunk.teamId,
   }));
 }
 
@@ -305,7 +316,7 @@ async function embedSubmissions(): Promise<EmbedSourceResult> {
   // Only embed finalized submissions — in_progress drafts are unstable.
   const { data: submissions, error } = await supabase
     .from('accel_submissions')
-    .select('id, text_content')
+    .select('id, text_content, team_id')
     .in('status', ['submitted', 'under_review', 'approved'])
     .not('text_content', 'is', null);
 
@@ -324,6 +335,7 @@ async function embedSubmissions(): Promise<EmbedSourceResult> {
   const documents = changed.map((submission) => ({
     id: submission.id,
     fullText: sanitizeSubmissionForEmbedding(submission.text_content as string),
+    teamId: submission.team_id as string | null,
   }));
 
   const rows = await buildChunkedRows(source, documents);
@@ -338,7 +350,7 @@ async function embedMeetingRecords(): Promise<EmbedSourceResult> {
 
   const { data: meetings, error } = await supabase
     .from('accel_meeting_records')
-    .select('id, notes')
+    .select('id, notes, team_id')
     .not('notes', 'is', null);
 
   if (error) throw new Error(`Failed to fetch meeting records: ${error.message}`);
@@ -356,6 +368,7 @@ async function embedMeetingRecords(): Promise<EmbedSourceResult> {
   const documents = changed.map((meeting) => ({
     id: meeting.id,
     fullText: meeting.notes as string,
+    teamId: meeting.team_id as string | null,
   }));
 
   const rows = await buildChunkedRows(source, documents);
@@ -395,7 +408,98 @@ async function embedContextDocs(): Promise<EmbedSourceResult> {
   return { source, upserted: rows.length, skipped: docs.length - changed.length };
 }
 
+async function embedTeamContext(): Promise<EmbedSourceResult> {
+  const source: EmbeddingSource = 'accel_team_context';
+  const supabase = createAdminClient();
+
+  const { data: contexts, error } = await supabase
+    .from('accel_team_context')
+    .select('id, team_id, context_key, content');
+
+  if (error) throw new Error(`Failed to fetch team context: ${error.message}`);
+  if (!contexts?.length) return { source, upserted: 0, skipped: 0 };
+
+  const existingHashes = await fetchExistingHashes(source);
+
+  const changed = contexts.filter((ctx) => {
+    const fullText = `${ctx.context_key}: ${ctx.content}`;
+    return existingHashes.get(ctx.id) !== md5(fullText);
+  });
+
+  if (changed.length === 0) return { source, upserted: 0, skipped: contexts.length };
+
+  const documents = changed.map((ctx) => ({
+    id: ctx.id,
+    fullText: `${ctx.context_key}: ${ctx.content}`,
+    teamId: ctx.team_id as string | null,
+  }));
+
+  const rows = await buildChunkedRows(source, documents);
+  await replaceEmbeddings(source, changed.map((ctx) => ctx.id), rows);
+
+  return { source, upserted: rows.length, skipped: contexts.length - changed.length };
+}
+
+async function embedCohortLessons(): Promise<EmbedSourceResult> {
+  const source: EmbeddingSource = 'accel_cohort_lessons';
+  const supabase = createAdminClient();
+
+  const { data: lessons, error } = await supabase
+    .from('accel_cohort_lessons')
+    .select('id, lesson_text');
+
+  if (error) throw new Error(`Failed to fetch cohort lessons: ${error.message}`);
+  if (!lessons?.length) return { source, upserted: 0, skipped: 0 };
+
+  const existingHashes = await fetchExistingHashes(source);
+
+  const changed = lessons.filter((lesson) => existingHashes.get(lesson.id) !== md5(lesson.lesson_text));
+
+  if (changed.length === 0) return { source, upserted: 0, skipped: lessons.length };
+
+  const documents = changed.map((lesson) => ({
+    id: lesson.id,
+    fullText: lesson.lesson_text,
+    teamId: null,
+  }));
+
+  const rows = await buildChunkedRows(source, documents);
+  await replaceEmbeddings(source, changed.map((l) => l.id), rows);
+
+  return { source, upserted: rows.length, skipped: lessons.length - changed.length };
+}
+
 // ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Embeds a single team context entry immediately after upsert without waiting
+ * for a full sync run. Used by the MCP handler and AI advisor tool.
+ */
+export async function embedTeamContextEntry(
+  teamId: string,
+  contextKey: string,
+  content: string,
+): Promise<void> {
+  const source: EmbeddingSource = 'accel_team_context';
+  const supabase = createAdminClient();
+
+  const { data: row } = await supabase
+    .from('accel_team_context')
+    .select('id')
+    .eq('team_id', teamId)
+    .eq('context_key', contextKey)
+    .single();
+
+  if (!row) return;
+
+  const fullText = `${contextKey}: ${content}`;
+  const existingHashes = await fetchExistingHashes(source);
+  const newHash = md5(fullText);
+  if (existingHashes.get(row.id) === newHash) return;
+
+  const rows = await buildChunkedRows(source, [{ id: row.id, fullText, teamId }]);
+  await replaceEmbeddings(source, [row.id], rows);
+}
 
 /**
  * Embeds a single curriculum file by ID. Used for immediate background indexing
@@ -457,6 +561,8 @@ export async function embedAllSources(): Promise<EmbedAllResult> {
     embedSubmissions(),
     embedMeetingRecords(),
     embedContextDocs(),
+    embedTeamContext(),
+    embedCohortLessons(),
   ]);
 
   const totalUpserted = results.reduce((sum, result) => sum + result.upserted, 0);

--- a/supabase/migrations/20260610000001_team_context_scoped_rag.sql
+++ b/supabase/migrations/20260610000001_team_context_scoped_rag.sql
@@ -1,0 +1,175 @@
+-- ============================================================
+-- AggieX Accelerator — Team-Scoped RAG + Team Context
+-- Created: 2026-06-10
+--
+-- Changes:
+--   1. Add team_id to accel_embeddings for content scoping
+--   2. Backfill team_id for submissions and meeting records
+--   3. Extend accel_embedding_source enum with two new values
+--   4. Create accel_team_context (per-team company knowledge)
+--   5. Create accel_cohort_lessons (abstracted, shared insights)
+--   6. Replace match_embeddings_hybrid() with team-scoped version
+-- ============================================================
+
+-- ─── 1. Add team_id to accel_embeddings ──────────────────────────────────────
+-- NULL = shared content (curriculum, deliverables, context docs, cohort lessons)
+-- Non-NULL = private content scoped to one team
+
+ALTER TABLE accel_embeddings
+  ADD COLUMN IF NOT EXISTS team_id uuid REFERENCES accel_teams(id) ON DELETE SET NULL;
+
+-- ─── 2. Backfill team_id for team-scoped source tables ───────────────────────
+
+UPDATE accel_embeddings e
+SET team_id = s.team_id
+FROM accel_submissions s
+WHERE e.source_table = 'accel_submissions'
+  AND e.source_id = s.id
+  AND e.team_id IS NULL;
+
+UPDATE accel_embeddings e
+SET team_id = mr.team_id
+FROM accel_meeting_records mr
+WHERE e.source_table = 'accel_meeting_records'
+  AND e.source_id = mr.id
+  AND e.team_id IS NULL;
+
+-- ─── 3. Extend accel_embedding_source enum ───────────────────────────────────
+
+ALTER TYPE accel_embedding_source ADD VALUE IF NOT EXISTS 'accel_team_context';
+ALTER TYPE accel_embedding_source ADD VALUE IF NOT EXISTS 'accel_cohort_lessons';
+
+-- ─── 4. accel_team_context ────────────────────────────────────────────────────
+-- Stores per-team structured company knowledge (ICP, market hypothesis, etc.).
+-- (team_id, context_key) is unique — upserts overwrite the previous value.
+-- updated_by = accountability ('founder' | 'aggiex_team')
+-- source     = mechanism ('direct_input' | 'ai_advisor' | 'mcp' | 'deliverable_submission' | 'meeting_notes')
+
+CREATE TABLE IF NOT EXISTS accel_team_context (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id     uuid        NOT NULL REFERENCES accel_teams(id) ON DELETE CASCADE,
+  context_key text        NOT NULL,
+  content     text        NOT NULL,
+  updated_by  text        NOT NULL CHECK (updated_by IN ('founder', 'aggiex_team')),
+  source      text        NOT NULL,
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (team_id, context_key)
+);
+
+ALTER TABLE accel_team_context ENABLE ROW LEVEL SECURITY;
+
+-- Founders: read only their own team's context rows
+CREATE POLICY "team_context_self_read" ON accel_team_context
+  FOR SELECT USING (
+    team_id = (
+      SELECT team_id FROM accel_profiles
+      WHERE id = auth.uid() AND is_active = true
+      LIMIT 1
+    )
+  );
+
+-- Staff and mentors: read all teams' context
+CREATE POLICY "team_context_staff_read" ON accel_team_context
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM accel_profiles
+      WHERE id = auth.uid()
+        AND role IN ('aggiex_team', 'mce_staff', 'mentor')
+        AND is_active = true
+    )
+  );
+
+-- ─── 5. accel_cohort_lessons ──────────────────────────────────────────────────
+-- Abstracted insights derived from accel_team_context by LLM.
+-- Team-identifying details are stripped before storage.
+-- content_hash prevents duplicate lessons from accumulating.
+-- team_id is always NULL — these rows belong to the shared embedding pool.
+
+CREATE TABLE IF NOT EXISTS accel_cohort_lessons (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  lesson_text  text        NOT NULL,
+  context_key  text,
+  content_hash text        NOT NULL UNIQUE,
+  derived_at   timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE accel_cohort_lessons ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "cohort_lessons_read" ON accel_cohort_lessons
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM accel_profiles
+      WHERE id = auth.uid() AND is_active = true
+    )
+  );
+
+-- ─── 6. Replace match_embeddings_hybrid with team-scoped version ──────────────
+-- p_team_id IS NOT NULL → return that team's private rows + shared rows (team_id IS NULL)
+-- p_team_id IS NULL     → no filter, return all rows (staff use case)
+
+CREATE OR REPLACE FUNCTION match_embeddings_hybrid(
+  query_embedding  vector(1024),
+  query_text       text,
+  match_count      int   DEFAULT 15,
+  rrf_k            int   DEFAULT 60,
+  p_team_id        uuid  DEFAULT NULL
+)
+RETURNS TABLE (
+  source_table  accel_embedding_source,
+  source_id     uuid,
+  chunk_index   integer,
+  chunk_text    text,
+  rrf_score     float
+)
+LANGUAGE sql STABLE
+AS $$
+  WITH vector_ranked AS (
+    SELECT
+      e.source_table,
+      e.source_id,
+      e.chunk_index,
+      e.chunk_text,
+      ROW_NUMBER() OVER (ORDER BY e.embedding <=> query_embedding) AS rank_vec
+    FROM accel_embeddings e
+    WHERE (p_team_id IS NULL OR e.team_id = p_team_id OR e.team_id IS NULL)
+    ORDER BY e.embedding <=> query_embedding
+    LIMIT match_count * 3
+  ),
+  bm25_ranked AS (
+    SELECT
+      e.source_table,
+      e.source_id,
+      e.chunk_index,
+      e.chunk_text,
+      ROW_NUMBER() OVER (
+        ORDER BY ts_rank_cd(e.search_vector, websearch_to_tsquery('english', query_text)) DESC
+      ) AS rank_bm25
+    FROM accel_embeddings e
+    WHERE e.search_vector @@ websearch_to_tsquery('english', query_text)
+      AND (p_team_id IS NULL OR e.team_id = p_team_id OR e.team_id IS NULL)
+    LIMIT match_count * 3
+  ),
+  combined AS (
+    SELECT
+      COALESCE(v.source_table, b.source_table) AS source_table,
+      COALESCE(v.source_id,    b.source_id)    AS source_id,
+      COALESCE(v.chunk_index,  b.chunk_index)  AS chunk_index,
+      COALESCE(v.chunk_text,   b.chunk_text)   AS chunk_text,
+      COALESCE(1.0 / (rrf_k + v.rank_vec),  0) +
+      COALESCE(1.0 / (rrf_k + b.rank_bm25), 0) AS rrf_score
+    FROM vector_ranked v
+    FULL OUTER JOIN bm25_ranked b
+      ON  v.source_table = b.source_table
+      AND v.source_id    = b.source_id
+      AND v.chunk_index  = b.chunk_index
+  )
+  SELECT
+    source_table,
+    source_id,
+    chunk_index,
+    chunk_text,
+    rrf_score
+  FROM combined
+  ORDER BY rrf_score DESC
+  LIMIT match_count;
+$$;


### PR DESCRIPTION
## Summary

- **RAG leakage fix**: adds `team_id` column to `accel_embeddings`; `match_embeddings_hybrid()` now accepts an optional `p_team_id` filter — founders only search their own team's private rows plus shared rows (`team_id IS NULL`), staff search across all
- **Per-team knowledge store**: new `accel_team_context` table (`team_id + context_key` unique key) — founders can save ICP, market hypothesis, beachhead, etc. via `update_company_context` advisor tool; staff can upsert via `upsert_team_context` MCP tool
- **Cohort abstraction**: new `accel_cohort_lessons` table + `cohort-abstraction.ts` — when staff sets a team context field, Groq 70B strips all identifying details and stores a generalised insight with `team_id = NULL` so it safely enriches RAG for all teams

## Architecture

```
Founder query → RAG filtered to (team_id = founder_team OR team_id IS NULL)
Staff query   → RAG unfiltered (all teams + shared pool)

accel_team_context  [team_id SET]   ← private per-team
accel_cohort_lessons [team_id NULL] ← abstracted, shared pool
```

`updated_by` = accountability ('founder' | 'aggiex_team')
`source` = provenance ('direct_input' | 'ai_advisor' | 'mcp' | …)
Cohort abstraction only fires when `updated_by = 'aggiex_team'`.

## Files changed

| File | Change |
|------|--------|
| `supabase/migrations/20260610000001_team_context_scoped_rag.sql` | New — migration |
| `my-app/lib/ai/cohort-abstraction.ts` | New — Groq abstraction module |
| `my-app/lib/ai/embedding-pipeline.ts` | team_id threading, new source embedders |
| `my-app/lib/ai/context-builder.ts` | COMPANY PROFILE section, scoped RAG |
| `my-app/app/api/accelerator/ai-advisor/route.ts` | team_id passed to RAG for founders |
| `my-app/app/api/mcp/tools.ts` | `upsert_team_context` staff tool |
| `my-app/lib/ai/advisor-tools.ts` | `update_company_context` + `upsert_team_context` tools |

## Test plan

- [ ] Founder A saves ICP via `update_company_context` — verify row in `accel_team_context` with `team_id = founder_A_team`
- [ ] Founder A's advisor session shows `## COMPANY PROFILE` section with saved context
- [ ] Founder B's advisor session does NOT surface Founder A's context
- [ ] Staff sets context via `upsert_team_context` (preview first, then with `confirm: true`)
- [ ] `accel_cohort_lessons` gains a row with `team_id = NULL` after staff upsert
- [ ] Cohort lesson appears in Founder B's semantic search results (shared pool)
- [ ] Run `embedAllSources()` — verify `accel_team_context` and `accel_cohort_lessons` rows appear in `accel_embeddings`
- [ ] Apply migration on staging; confirm backfill sets `team_id` on existing submission/meeting-record embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)