### PR TITLE
feat: Relays network search + mentor intro flow

### DIFF
--- a/my-app/app/accelerator/(platform)/components/accelerator-sidebar.tsx
+++ b/my-app/app/accelerator/(platform)/components/accelerator-sidebar.tsx
@@ -23,6 +23,7 @@ import {
   ExternalLink,
   X,
   Code2,
+  Network,
 } from 'lucide-react';
 import type { AccelRole } from '@/lib/accel-types';
 
@@ -126,6 +127,12 @@ const NAV_GROUPS: NavGroup[] = [
         label: 'My Team',
         href: '/accelerator/my-team',
         icon: Users,
+        roles: ['founder'],
+      },
+      {
+        label: 'Network',
+        href: '/accelerator/network',
+        icon: Network,
         roles: ['founder'],
       },
       {

--- a/my-app/app/accelerator/(platform)/network/components/network-search.tsx
+++ b/my-app/app/accelerator/(platform)/network/components/network-search.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Search, UserCheck, Lock, CheckCircle2, Loader2, Send } from 'lucide-react';
+import type { RelaysResult } from '@/lib/relays';
+
+type IntroStatus = 'idle' | 'requesting' | 'requested';
+
+interface ResultWithIntro extends RelaysResult {
+  introStatus: IntroStatus;
+}
+
+export default function NetworkSearch() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<ResultWithIntro[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [pendingResultIds, setPendingResultIds] = useState<Set<string>>(new Set());
+  const [hasSearched, setHasSearched] = useState(false);
+
+  // Load existing intro requests on mount so buttons show correct state
+  useEffect(() => {
+    fetch('/api/accelerator/relays/intro')
+      .then((r) => r.json())
+      .then((data: Array<{ result_id: string }>) => {
+        setPendingResultIds(new Set(data.map((r) => r.result_id)));
+      })
+      .catch(() => {});
+
+    // Provision this user on first network page visit (idempotent)
+    fetch('/api/accelerator/relays/provision', { method: 'POST' }).catch(() => {});
+  }, []);
+
+  const runSearch = useCallback(async (queryText: string) => {
+    if (!queryText.trim()) return;
+    setIsSearching(true);
+    setSearchError(null);
+    setHasSearched(true);
+
+    try {
+      const res = await fetch('/api/accelerator/relays/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: queryText }),
+      });
+
+      if (!res.ok) {
+        const { error } = await res.json();
+        setSearchError(error ?? 'Search failed. Please try again.');
+        setResults([]);
+        return;
+      }
+
+      const data = await res.json();
+      const enriched: ResultWithIntro[] = (data.results ?? []).map(
+        (r: RelaysResult) => ({
+          ...r,
+          introStatus: pendingResultIds.has(r.result_id) ? 'requested' : 'idle',
+        }),
+      );
+      setResults(enriched);
+    } catch {
+      setSearchError('Network error. Please try again.');
+      setResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  }, [pendingResultIds]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    runSearch(query);
+  };
+
+  const requestIntro = async (resultId: string, message?: string) => {
+    setResults((previous) =>
+      previous.map((r) =>
+        r.result_id === resultId ? { ...r, introStatus: 'requesting' } : r,
+      ),
+    );
+
+    try {
+      const res = await fetch('/api/accelerator/relays/intro', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ result_id: resultId, message }),
+      });
+
+      if (res.ok) {
+        setPendingResultIds((prev) => new Set(prev).add(resultId));
+        setResults((previous) =>
+          previous.map((r) =>
+            r.result_id === resultId ? { ...r, introStatus: 'requested' } : r,
+          ),
+        );
+      } else {
+        setResults((previous) =>
+          previous.map((r) =>
+            r.result_id === resultId ? { ...r, introStatus: 'idle' } : r,
+          ),
+        );
+      }
+    } catch {
+      setResults((previous) =>
+        previous.map((r) =>
+          r.result_id === resultId ? { ...r, introStatus: 'idle' } : r,
+        ),
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Search bar */}
+      <form onSubmit={handleSubmit} className="relative">
+        <div className="pointer-events-none absolute inset-y-0 left-3.5 flex items-center">
+          {isSearching ? (
+            <Loader2 size={15} className="animate-spin text-neutral-500" />
+          ) : (
+            <Search size={15} className="text-neutral-500" />
+          )}
+        </div>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search by expertise, industry, role…"
+          className="w-full rounded-lg border border-neutral-800 bg-neutral-900 py-2.5 pl-9 pr-4
+            text-sm text-neutral-100 placeholder-neutral-600 outline-none
+            focus:border-neutral-600 focus:ring-0 transition-colors"
+        />
+        <button type="submit" className="sr-only">Search</button>
+      </form>
+
+      {/* Error */}
+      {searchError && (
+        <p className="text-sm text-red-400">{searchError}</p>
+      )}
+
+      {/* Empty state */}
+      {hasSearched && !isSearching && results.length === 0 && !searchError && (
+        <div className="rounded-lg border border-neutral-800 px-4 py-14 text-center">
+          <p className="text-sm text-neutral-500">No matches found.</p>
+          <p className="mt-1 text-xs text-neutral-700">Try a different search — expertise area, industry, or role.</p>
+        </div>
+      )}
+
+      {/* Results */}
+      {results.length > 0 && (
+        <div className="space-y-3">
+          {results.map((result) => (
+            <ResultCard
+              key={result.result_id}
+              result={result}
+              onRequestIntro={requestIntro}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Hint before first search */}
+      {!hasSearched && (
+        <div className="rounded-lg border border-neutral-800/50 px-5 py-10 text-center">
+          <Search size={24} className="mx-auto mb-3 text-neutral-700" />
+          <p className="text-sm text-neutral-500">
+            Search for mentors and investors in the AggieX network.
+          </p>
+          <p className="mt-1 text-xs text-neutral-700">
+            Some profiles are anonymized — you can request an intro and a relationship manager will facilitate.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Result card ─────────────────────────────────────────────────────────────
+
+interface ResultCardProps {
+  result: ResultWithIntro;
+  onRequestIntro: (resultId: string) => void;
+}
+
+function ResultCard({ result, onRequestIntro }: ResultCardProps) {
+  const isAnonymized = result.visibility === 'anonymized';
+
+  return (
+    <div className="rounded-lg border border-neutral-800 bg-neutral-900/40 px-5 py-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {isAnonymized ? (
+              <Lock size={13} className="shrink-0 text-neutral-600" />
+            ) : (
+              <UserCheck size={13} className="shrink-0 text-emerald-600" />
+            )}
+
+            {isAnonymized ? (
+              <span className="text-sm font-medium text-neutral-400">
+                {result.anon_description ?? 'Anonymous profile'}
+              </span>
+            ) : (
+              <span className="text-sm font-semibold text-neutral-100">
+                {result.full_name}
+              </span>
+            )}
+          </div>
+
+          {!isAnonymized && (result.role_title || result.company) && (
+            <p className="mt-0.5 pl-5 text-xs text-neutral-500">
+              {[result.role_title, result.company].filter(Boolean).join(' · ')}
+            </p>
+          )}
+
+          {isAnonymized && result.expertise_signals && result.expertise_signals.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5 pl-5">
+              {result.expertise_signals.map((signal) => (
+                <span
+                  key={signal}
+                  className="rounded bg-neutral-800 px-2 py-0.5 text-[10px] text-neutral-400"
+                >
+                  {signal}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Match score */}
+        <span className="shrink-0 text-[10px] font-medium uppercase tracking-wider text-neutral-700">
+          {Math.round(result.score * 100)}% match
+        </span>
+      </div>
+
+      {/* Intro action */}
+      {result.requires_approval && (
+        <div className="mt-3 flex justify-end border-t border-neutral-800 pt-3">
+          {result.introStatus === 'requested' ? (
+            <span className="flex items-center gap-1.5 text-xs text-emerald-600">
+              <CheckCircle2 size={13} />
+              Intro requested — a relationship manager will reach out.
+            </span>
+          ) : (
+            <button
+              onClick={() => onRequestIntro(result.result_id)}
+              disabled={result.introStatus === 'requesting'}
+              className="flex items-center gap-1.5 rounded-md border border-neutral-700
+                px-3 py-1.5 text-xs text-neutral-300 transition-colors
+                hover:border-neutral-500 hover:text-neutral-100
+                disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {result.introStatus === 'requesting' ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Send size={12} />
+              )}
+              Request intro
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/my-app/app/accelerator/(platform)/network/page.tsx
+++ b/my-app/app/accelerator/(platform)/network/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import type { AccelRole } from '@/lib/accel-types';
+import NetworkSearch from './components/network-search';
+
+export default async function NetworkPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/auth/login');
+
+  const { data: profile } = await supabase
+    .from('accel_profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (!profile) redirect('/accelerator/access-denied');
+
+  const role = profile.role as AccelRole;
+
+  if (role !== 'founder') redirect('/accelerator/dashboard');
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-8">
+      <div className="mb-8">
+        <p className="text-xs uppercase tracking-widest text-neutral-500">People</p>
+        <h1 className="mt-1 text-xl font-semibold text-neutral-100">Network</h1>
+        <p className="mt-0.5 text-sm text-neutral-500">
+          Search for mentors and investors. Introductions are facilitated by a relationship manager.
+        </p>
+      </div>
+
+      <NetworkSearch />
+    </div>
+  );
+}

--- a/my-app/app/api/accelerator/relays/intro/route.ts
+++ b/my-app/app/api/accelerator/relays/intro/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAccelAuth } from '@/lib/accel-auth';
+import { createAdminClient } from '@/lib/supabase/accel-admin';
+
+const IntroSchema = z.object({
+  result_id: z.string().min(1),
+  message: z.string().max(500).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const { profile, error } = await requireAccelAuth(request, ['founder']);
+  if (error) return error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = IntroSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 422 });
+  }
+
+  const admin = createAdminClient();
+  const { error: dbError } = await admin
+    .from('accel_intro_requests')
+    .upsert(
+      {
+        requester_id: profile.id,
+        result_id: parsed.data.result_id,
+        message: parsed.data.message ?? null,
+        status: 'pending',
+        requested_at: new Date().toISOString(),
+      },
+      { onConflict: 'requester_id,result_id', ignoreDuplicates: true },
+    );
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET(request: NextRequest) {
+  const { profile, error } = await requireAccelAuth(request, ['founder']);
+  if (error) return error;
+
+  const admin = createAdminClient();
+  const { data, error: dbError } = await admin
+    .from('accel_intro_requests')
+    .select('result_id, status, requested_at')
+    .eq('requester_id', profile.id);
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data ?? []);
+}

--- a/my-app/app/api/accelerator/relays/provision/route.ts
+++ b/my-app/app/api/accelerator/relays/provision/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAccelAuth } from '@/lib/accel-auth';
+import { createAdminClient } from '@/lib/supabase/accel-admin';
+import { provisionMember } from '@/lib/relays';
+import type { AccelRole } from '@/lib/accel-types';
+
+// Idempotent — safe to call on every session start.
+// Provisions the authenticated user into Relays with their current profile data.
+export async function POST(request: NextRequest) {
+  const { profile, error } = await requireAccelAuth(request, [
+    'founder', 'aggiex_team', 'mce_staff', 'mentor',
+  ]);
+  if (error) return error;
+
+  const admin = createAdminClient();
+  const { data: mentorProfile } = await admin
+    .from('accel_mentor_profiles')
+    .select('bio, title, company')
+    .eq('id', profile.id)
+    .maybeSingle();
+
+  await provisionMember({
+    external_user_id: profile.id,
+    role: profile.role as AccelRole,
+    full_name: profile.full_name ?? '',
+    email: profile.email ?? '',
+    title: mentorProfile?.title ?? null,
+    company: mentorProfile?.company ?? null,
+    bio: mentorProfile?.bio ?? null,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/my-app/app/api/accelerator/relays/search/route.ts
+++ b/my-app/app/api/accelerator/relays/search/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAccelAuth } from '@/lib/accel-auth';
+import { searchNetwork } from '@/lib/relays';
+
+const SearchSchema = z.object({
+  query: z.string().min(1).max(300),
+  purpose: z.string().max(200).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const { profile, error } = await requireAccelAuth(request, [
+    'founder', 'aggiex_team', 'mce_staff', 'mentor',
+  ]);
+  if (error) return error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = SearchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 422 });
+  }
+
+  const results = await searchNetwork(profile.id, parsed.data.query, parsed.data.purpose);
+  return NextResponse.json(results);
+}

--- a/my-app/lib/relays.ts
+++ b/my-app/lib/relays.ts
@@ -1,0 +1,112 @@
+import type { AccelRole } from '@/lib/accel-types';
+
+const BASE = process.env.RELAYS_BASE_URL!;
+const KEY = process.env.RELAYS_API_KEY!;
+
+export type RelaysOutcome =
+  | 'meeting_happened'
+  | 'ongoing_relationship'
+  | 'led_to_funding'
+  | 'led_to_event'
+  | 'no_response'
+  | 'declined_after_intro'
+  | 'other';
+
+export interface RelaysResult {
+  result_id: string;
+  score: number;
+  visibility: 'visible' | 'anonymized';
+  requires_approval: boolean;
+  connection_degree: number;
+  full_name?: string;
+  role_title?: string;
+  company?: string;
+  anon_description?: string;
+  expertise_signals?: string[];
+}
+
+export interface RelaysSearchResponse {
+  results: RelaysResult[];
+  confidence: number;
+}
+
+// Maps AccelRole → Relays role_key
+const ROLE_KEY_MAP: Record<AccelRole, string> = {
+  founder: 'founder',
+  aggiex_team: 'aggiex_team',
+  mce_staff: 'mce_team',
+  mentor: 'mentor',
+};
+
+export function toRelaysRoleKey(role: AccelRole): string {
+  return ROLE_KEY_MAP[role] ?? role;
+}
+
+async function call<T = unknown>(
+  path: string,
+  token: string,
+  body?: unknown,
+  method = 'POST',
+): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Relays ${path} ${res.status}: ${text}`);
+  }
+  return res.status === 204 ? (null as T) : (res.json() as Promise<T>);
+}
+
+export async function provisionMember(user: {
+  external_user_id: string;
+  role: AccelRole;
+  full_name: string;
+  email: string;
+  title?: string | null;
+  company?: string | null;
+  bio?: string | null;
+}): Promise<void> {
+  await call('/v1/identities', KEY, {
+    external_user_id: user.external_user_id,
+    role_key: toRelaysRoleKey(user.role),
+    full_name: user.full_name,
+    email: user.email,
+    ...(user.title && { title: user.title }),
+    ...(user.company && { company: user.company }),
+    ...(user.bio && { bio: user.bio }),
+  });
+}
+
+async function getUserToken(externalUserId: string): Promise<string> {
+  const response = await call<{ access_token: string }>('/v1/tokens', KEY, {
+    external_user_id: externalUserId,
+  });
+  return response.access_token;
+}
+
+export async function searchNetwork(
+  externalUserId: string,
+  queryText: string,
+  purpose?: string,
+): Promise<RelaysSearchResponse> {
+  const token = await getUserToken(externalUserId);
+  return call<RelaysSearchResponse>('/v1/match/query', token, {
+    query_text: queryText,
+    ...(purpose && { purpose }),
+  });
+}
+
+export async function logOutcome(
+  externalUserId: string,
+  resultId: string,
+  outcome: RelaysOutcome,
+): Promise<void> {
+  const token = await getUserToken(externalUserId);
+  await call('/v1/match/outcome', token, { result_id: resultId, outcome });
+}


### PR DESCRIPTION
## Summary

- **Founders can search the AggieX network** for mentors and investors via `/accelerator/network`
- **Anonymized results** (mentors, investors) show expertise signals and a "Request intro" button — a relationship manager facilitates the connection
- **Visible results** (other founders) show full name/title/company directly
- **Intro state persists** — on page load the component fetches existing requests so the button stays in "requested" state across sessions

## Architecture

```
Founder browser
  → POST /api/accelerator/relays/search  (proxied, uses founder's Relays user token)
  → POST /api/accelerator/relays/intro   (stores in accel_intro_requests)
  → GET  /api/accelerator/relays/intro   (hydrates existing requests on mount)

lib/relays.ts  — server-side Relays client (never reaches browser)
```

Provision is called once per network page visit (idempotent) to keep Relays membership current.

## Env vars required

```
RELAYS_API_KEY=ak_...
RELAYS_BASE_URL=https://relays-six.vercel.app/api
```

## Migration required

Apply `supabase/migrations/20260615000001_relays_intro_requests.sql` before deploying:
- Creates `accel_intro_requests` table
- RLS: founders own their rows; staff can read/update all

## Files

| File | Purpose |
|---|---|
| `my-app/lib/relays.ts` | Relays API client |
| `my-app/app/api/accelerator/relays/provision/route.ts` | Idempotent member provisioning |
| `my-app/app/api/accelerator/relays/search/route.ts` | Search proxy |
| `my-app/app/api/accelerator/relays/intro/route.ts` | Intro request CRUD |
| `my-app/app/accelerator/(platform)/network/page.tsx` | Founder network page |
| `my-app/app/accelerator/(platform)/network/components/network-search.tsx` | Search + result UI |
| `accelerator-sidebar.tsx` | "Network" nav item for founders |

🤖 Generated with [Claude Code](https://claude.com/claude-code)